### PR TITLE
Add blanket implementation for the `AsAny` trait

### DIFF
--- a/src/generator/misc.rs
+++ b/src/generator/misc.rs
@@ -537,7 +537,13 @@ pub(super) fn format_field_name(name: &Name, display_name: Option<&str>) -> Cow<
 
     match KEYWORDS.binary_search_by(|(key, _)| key.cmp(&ident.as_str())) {
         Ok(idx) => Cow::Borrowed(KEYWORDS[idx].1),
-        Err(_) => Cow::Owned(ident),
+        Err(_) => {
+            if ident.starts_with(char::is_numeric) {
+                Cow::Owned(format!("_{ident}"))
+            } else {
+                Cow::Owned(ident)
+            }
+        }
     }
 }
 
@@ -556,10 +562,17 @@ pub(super) fn format_type_name(name: &Name, display_name: Option<&str>) -> Strin
         return display_name.to_pascal_case();
     }
 
-    name.to_type_name(false, None)
+    let name = name
+        .to_type_name(false, None)
         .as_str()
         .unwrap()
-        .to_pascal_case()
+        .to_pascal_case();
+
+    if name.starts_with(char::is_numeric) {
+        format!("_{name}")
+    } else {
+        name
+    }
 }
 
 pub(super) fn format_type_ident(name: &Name, display_name: Option<&str>) -> Ident2 {

--- a/src/generator/renderer/types.rs
+++ b/src/generator/renderer/types.rs
@@ -381,10 +381,6 @@ impl TypeRenderer {
         type_data: &'a TypeData<'_, '_>,
         trait_data: &'a [TraitData],
     ) -> impl Iterator<Item = TokenStream> + 'a {
-        let trait_as_any = trait_data
-            .is_empty()
-            .not()
-            .then(|| Self::render_trait_as_any(type_data));
         let trait_with_namespace = type_data
             .check_generate_flags(GenerateFlags::WITH_NAMESPACE_TRAIT)
             .then(|| Self::render_trait_with_namespace(type_data))
@@ -398,24 +394,7 @@ impl TypeRenderer {
                     impl #trait_ident for #type_ident { }
                 }
             })
-            .chain(trait_as_any)
             .chain(trait_with_namespace)
-    }
-
-    fn render_trait_as_any(data: &TypeData<'_, '_>) -> TokenStream {
-        let xsd_parser = &data.xsd_parser_crate;
-        let type_ident = &data.current_type_ref().type_ident;
-
-        quote! {
-            impl #xsd_parser::AsAny for #type_ident {
-                fn as_any(&self) -> &dyn core::any::Any {
-                    self
-                }
-                fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-                    self
-                }
-            }
-        }
     }
 
     fn render_trait_with_namespace(data: &TypeData<'_, '_>) -> Option<TokenStream> {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -27,6 +27,16 @@ pub trait AsAny: core::any::Any {
     fn as_any_mut(&mut self) -> &mut dyn core::any::Any;
 }
 
+impl<X: 'static> AsAny for X {
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+}
+
 /// Error emitted by the [`generate`](crate::generate) function.
 #[derive(Debug, Error)]
 pub enum Error {

--- a/tests/optimizer/expected0/convert_dynamic_to_choice.rs
+++ b/tests/optimizer/expected0/convert_dynamic_to_choice.rs
@@ -4,24 +4,8 @@ pub struct FirstType {
     pub a: String,
 }
 impl AbstractTrait for FirstType {}
-impl xsd_parser::AsAny for FirstType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}
 pub enum SecondType {
     Var1,
     Var2,
 }
 impl AbstractTrait for SecondType {}
-impl xsd_parser::AsAny for SecondType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}

--- a/tests/schema/dynamic_types/expected/default.rs
+++ b/tests/schema/dynamic_types/expected/default.rs
@@ -13,14 +13,6 @@ pub struct IntermediateType {
 }
 impl BaseTrait for IntermediateType {}
 impl IntermediateTrait for IntermediateType {}
-impl xsd_parser::AsAny for IntermediateType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}
 #[derive(Debug)]
 pub struct FinalType {
     pub base_value: Option<i32>,
@@ -29,14 +21,6 @@ pub struct FinalType {
 }
 impl BaseTrait for FinalType {}
 impl IntermediateTrait for FinalType {}
-impl xsd_parser::AsAny for FinalType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}
 #[derive(Debug)]
 pub struct Intermediate(pub Box<dyn IntermediateTrait>);
 pub trait IntermediateTrait: BaseTrait {}

--- a/tests/schema/dynamic_types/expected/quick_xml.rs
+++ b/tests/schema/dynamic_types/expected/quick_xml.rs
@@ -43,14 +43,6 @@ pub struct IntermediateType {
 }
 impl BaseTrait for IntermediateType {}
 impl IntermediateTrait for IntermediateType {}
-impl xsd_parser::AsAny for IntermediateType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}
 impl xsd_parser::quick_xml::WithSerializer for IntermediateType {
     type Serializer<'x> = quick_xml_serialize::IntermediateTypeSerializer<'x>;
     fn serializer<'ser>(
@@ -72,14 +64,6 @@ pub struct FinalType {
 }
 impl BaseTrait for FinalType {}
 impl IntermediateTrait for FinalType {}
-impl xsd_parser::AsAny for FinalType {
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
-    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
-        self
-    }
-}
 impl xsd_parser::quick_xml::WithSerializer for FinalType {
     type Serializer<'x> = quick_xml_serialize::FinalTypeSerializer<'x>;
     fn serializer<'ser>(

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -11,6 +11,7 @@ mod extension_base_multilayer;
 mod extension_base_two_files;
 mod extension_simple_content;
 mod list;
+mod numeric_fields;
 mod ref_to_attribute;
 mod sequence;
 mod sequence_with_choice;

--- a/tests/schema/numeric_fields/example/default.xml
+++ b/tests/schema/numeric_fields/example/default.xml
@@ -1,0 +1,3 @@
+<tns:Foo xmlns:tns="http://example.com">
+    <tns:4>1</tns:4>
+</tns:Foo>

--- a/tests/schema/numeric_fields/expected/default.rs
+++ b/tests/schema/numeric_fields/expected/default.rs
@@ -1,0 +1,11 @@
+pub type Foo = FooType;
+#[derive(Debug, Clone)]
+pub struct FooType {
+    pub _4: EnumType,
+}
+#[derive(Debug, Clone)]
+pub enum EnumType {
+    _1,
+    _2,
+    _3,
+}

--- a/tests/schema/numeric_fields/expected/quick_xml.rs
+++ b/tests/schema/numeric_fields/expected/quick_xml.rs
@@ -1,0 +1,348 @@
+pub type Foo = FooType;
+#[derive(Debug, Clone)]
+pub struct FooType {
+    pub _4: EnumType,
+}
+impl xsd_parser::quick_xml::WithSerializer for FooType {
+    type Serializer<'x> = quick_xml_serialize::FooTypeSerializer<'x>;
+    fn serializer<'ser>(
+        &'ser self,
+        name: Option<&'ser str>,
+        is_root: bool,
+    ) -> Result<Self::Serializer<'ser>, xsd_parser::quick_xml::Error> {
+        quick_xml_serialize::FooTypeSerializer::new(self, name, is_root)
+    }
+}
+impl xsd_parser::quick_xml::WithDeserializer for FooType {
+    type Deserializer = quick_xml_deserialize::FooTypeDeserializer;
+}
+#[derive(Debug, Clone)]
+pub enum EnumType {
+    _1,
+    _2,
+    _3,
+}
+impl xsd_parser::quick_xml::SerializeBytes for EnumType {
+    fn serialize_bytes(
+        &self,
+    ) -> Result<Option<std::borrow::Cow<'_, str>>, xsd_parser::quick_xml::Error> {
+        match self {
+            Self::_1 => Ok(Some(std::borrow::Cow::Borrowed("1"))),
+            Self::_2 => Ok(Some(std::borrow::Cow::Borrowed("2"))),
+            Self::_3 => Ok(Some(std::borrow::Cow::Borrowed("3"))),
+        }
+    }
+}
+impl xsd_parser::quick_xml::DeserializeBytes for EnumType {
+    fn deserialize_bytes<R>(reader: &R, bytes: &[u8]) -> Result<Self, xsd_parser::quick_xml::Error>
+    where
+        R: xsd_parser::quick_xml::XmlReader,
+    {
+        match bytes {
+            b"1" => Ok(Self::_1),
+            b"2" => Ok(Self::_2),
+            b"3" => Ok(Self::_3),
+            x => {
+                use xsd_parser::quick_xml::{ErrorKind, RawByteStr};
+                Err(reader.map_error(ErrorKind::UnknownOrInvalidValue(RawByteStr::from_slice(x))))
+            }
+        }
+    }
+}
+pub mod quick_xml_serialize {
+    use super::*;
+    #[derive(Debug)]
+    pub struct FooTypeSerializer<'ser> {
+        name: &'ser str,
+        value: &'ser super::FooType,
+        is_root: bool,
+        state: FooTypeSerializerState<'ser>,
+    }
+    #[derive(Debug)]
+    enum FooTypeSerializerState<'ser> {
+        Init__,
+        _4(xsd_parser::quick_xml::ContentSerializer<'ser, EnumType>),
+        End__,
+        Done__,
+        Phantom__(&'ser ()),
+    }
+    impl<'ser> FooTypeSerializer<'ser> {
+        pub(super) fn new(
+            value: &'ser super::FooType,
+            name: Option<&'ser str>,
+            is_root: bool,
+        ) -> Result<Self, xsd_parser::quick_xml::Error> {
+            let name = name.unwrap_or("tns:FooType");
+            Ok(Self {
+                name,
+                value,
+                is_root,
+                state: FooTypeSerializerState::Init__,
+            })
+        }
+    }
+    impl<'ser> core::iter::Iterator for FooTypeSerializer<'ser> {
+        type Item = Result<xsd_parser::quick_xml::Event<'ser>, xsd_parser::quick_xml::Error>;
+        fn next(&mut self) -> Option<Self::Item> {
+            use xsd_parser::quick_xml::{
+                BytesEnd, BytesStart, Error, Event, Serializer, WithSerializer,
+            };
+            loop {
+                match &mut self.state {
+                    FooTypeSerializerState::Init__ => {
+                        self.state = FooTypeSerializerState::_4(
+                            xsd_parser::quick_xml::ContentSerializer::new(
+                                &self.value._4,
+                                Some("tns:4"),
+                                false,
+                            ),
+                        );
+                        let mut bytes = BytesStart::new(self.name);
+                        if self.is_root {
+                            bytes.push_attribute(("xmlns:tns", "http://example.com"));
+                        }
+                        return Some(Ok(Event::Start(bytes)));
+                    }
+                    FooTypeSerializerState::_4(x) => match x.next() {
+                        Some(Ok(event)) => return Some(Ok(event)),
+                        Some(Err(error)) => {
+                            self.state = FooTypeSerializerState::Done__;
+                            return Some(Err(error));
+                        }
+                        None => self.state = FooTypeSerializerState::End__,
+                    },
+                    FooTypeSerializerState::End__ => {
+                        self.state = FooTypeSerializerState::Done__;
+                        return Some(Ok(Event::End(BytesEnd::new(self.name))));
+                    }
+                    FooTypeSerializerState::Done__ => return None,
+                    FooTypeSerializerState::Phantom__(_) => unreachable!(),
+                }
+            }
+        }
+    }
+}
+pub mod quick_xml_deserialize {
+    use super::*;
+    #[derive(Debug)]
+    pub struct FooTypeDeserializer {
+        _4: Option<super::EnumType>,
+        state: Box<FooTypeDeserializerState>,
+    }
+    #[derive(Debug)]
+    enum FooTypeDeserializerState {
+        _4(Option<<EnumType as xsd_parser::quick_xml::WithDeserializer>::Deserializer>),
+        Done__,
+    }
+    impl FooTypeDeserializer {
+        fn from_bytes_start<R>(
+            reader: &R,
+            bytes_start: &xsd_parser::quick_xml::BytesStart<'_>,
+        ) -> Result<Self, xsd_parser::quick_xml::Error>
+        where
+            R: xsd_parser::quick_xml::XmlReader,
+        {
+            use xsd_parser::quick_xml::ErrorKind;
+            for attrib in bytes_start.attributes() {
+                let attrib = attrib?;
+                if matches ! (attrib . key . prefix () , Some (x) if x . as_ref () == b"xmlns") {
+                    continue;
+                }
+                reader.err(ErrorKind::UnexpectedAttribute(
+                    xsd_parser::quick_xml::RawByteStr::from_slice(attrib.key.into_inner()),
+                ))?;
+            }
+            Ok(Self {
+                _4: None,
+                state: Box::new(FooTypeDeserializerState::_4(None)),
+            })
+        }
+    }
+    impl<'de> xsd_parser::quick_xml::Deserializer<'de, super::FooType> for FooTypeDeserializer {
+        fn init<R>(
+            reader: &R,
+            event: xsd_parser::quick_xml::Event<'de>,
+        ) -> xsd_parser::quick_xml::DeserializerResult<'de, super::FooType, Self>
+        where
+            R: xsd_parser::quick_xml::XmlReader,
+        {
+            use xsd_parser::quick_xml::{DeserializerOutput, Event};
+            match event {
+                Event::Start(start) => {
+                    let deserializer = Self::from_bytes_start(reader, &start)?;
+                    Ok(DeserializerOutput {
+                        data: None,
+                        deserializer: Some(deserializer),
+                        event: None,
+                        allow_any: false,
+                    })
+                }
+                Event::Empty(start) => {
+                    let deserializer = Self::from_bytes_start(reader, &start)?;
+                    let data = deserializer.finish(reader)?;
+                    Ok(DeserializerOutput {
+                        data: Some(data),
+                        deserializer: None,
+                        event: None,
+                        allow_any: false,
+                    })
+                }
+                event => Ok(DeserializerOutput {
+                    data: None,
+                    deserializer: None,
+                    event: Some(event),
+                    allow_any: false,
+                }),
+            }
+        }
+        fn next<R>(
+            mut self,
+            reader: &R,
+            event: xsd_parser::quick_xml::Event<'de>,
+        ) -> xsd_parser::quick_xml::DeserializerResult<'de, super::FooType, Self>
+        where
+            R: xsd_parser::quick_xml::XmlReader,
+        {
+            use xsd_parser::quick_xml::{
+                Deserializer, DeserializerOutput, ErrorKind, Event, RawByteStr, WithDeserializer,
+            };
+            const NS_TNS: &[u8] = b"http://example.com";
+            let mut event = event;
+            let mut allow_any_fallback = None;
+            loop {
+                event = match (
+                    core::mem::replace(&mut *self.state, FooTypeDeserializerState::Done__),
+                    event,
+                ) {
+                    (FooTypeDeserializerState::_4(Some(deserializer)), event) => {
+                        let DeserializerOutput {
+                            data,
+                            deserializer,
+                            event,
+                            allow_any,
+                        } = deserializer.next(reader, event)?;
+                        if let Some(data) = data {
+                            if self._4.is_some() {
+                                Err(ErrorKind::DuplicateElement(RawByteStr::from_slice(b"4")))?;
+                            }
+                            self._4 = Some(data);
+                        }
+                        let event = match event {
+                            Some(event @ (Event::Start(_) | Event::Empty(_) | Event::End(_))) => {
+                                event
+                            }
+                            event => {
+                                *self.state = FooTypeDeserializerState::_4(deserializer);
+                                return Ok(DeserializerOutput {
+                                    data: None,
+                                    deserializer: Some(self),
+                                    event: event,
+                                    allow_any: false,
+                                });
+                            }
+                        };
+                        if allow_any {
+                            allow_any_fallback
+                                .get_or_insert(FooTypeDeserializerState::_4(deserializer));
+                        } else if let Some(deserializer) = deserializer {
+                            let data = deserializer.finish(reader)?;
+                            if self._4.is_some() {
+                                Err(ErrorKind::DuplicateElement(RawByteStr::from_slice(b"4")))?;
+                            }
+                            self._4 = Some(data);
+                        }
+                        *self.state = FooTypeDeserializerState::_4(None);
+                        event
+                    }
+                    (FooTypeDeserializerState::_4(None), event) => match &event {
+                        Event::Start(x) | Event::Empty(x)
+                            if matches!(
+                                reader.resolve_local_name(x.name(), NS_TNS),
+                                Some(b"4")
+                            ) =>
+                        {
+                            let DeserializerOutput {
+                                data,
+                                deserializer,
+                                event,
+                                allow_any,
+                            } = <EnumType as WithDeserializer>::Deserializer::init(reader, event)?;
+                            if let Some(data) = data {
+                                if self._4.is_some() {
+                                    Err(ErrorKind::DuplicateElement(RawByteStr::from_slice(b"4")))?;
+                                }
+                                self._4 = Some(data);
+                            }
+                            *self.state = FooTypeDeserializerState::_4(deserializer);
+                            match event {
+                                Some(event @ (Event::Start(_) | Event::End(_))) => {
+                                    *self.state = FooTypeDeserializerState::Done__;
+                                    if allow_any {
+                                        allow_any_fallback
+                                            .get_or_insert(FooTypeDeserializerState::_4(None));
+                                    }
+                                    event
+                                }
+                                event @ (None | Some(_)) => {
+                                    return Ok(DeserializerOutput {
+                                        data: None,
+                                        deserializer: Some(self),
+                                        event,
+                                        allow_any: false,
+                                    })
+                                }
+                            }
+                        }
+                        Event::Start(_) | Event::Empty(_) => {
+                            *self.state = FooTypeDeserializerState::Done__;
+                            event
+                        }
+                        Event::End(_) => {
+                            let data = self.finish(reader)?;
+                            return Ok(DeserializerOutput {
+                                data: Some(data),
+                                deserializer: None,
+                                event: None,
+                                allow_any: false,
+                            });
+                        }
+                        _ => {
+                            *self.state = FooTypeDeserializerState::_4(None);
+                            return Ok(DeserializerOutput {
+                                data: None,
+                                deserializer: Some(self),
+                                event: Some(event),
+                                allow_any: false,
+                            });
+                        }
+                    },
+                    (FooTypeDeserializerState::Done__, event) => {
+                        let allow_any = if let Some(fallback) = allow_any_fallback {
+                            *self.state = fallback;
+                            true
+                        } else {
+                            false
+                        };
+                        return Ok(DeserializerOutput {
+                            data: None,
+                            deserializer: Some(self),
+                            event: Some(event),
+                            allow_any,
+                        });
+                    }
+                }
+            }
+        }
+        fn finish<R>(self, _reader: &R) -> Result<super::FooType, xsd_parser::quick_xml::Error>
+        where
+            R: xsd_parser::quick_xml::XmlReader,
+        {
+            use xsd_parser::quick_xml::ErrorKind;
+            Ok(super::FooType {
+                _4: self
+                    ._4
+                    .ok_or_else(|| ErrorKind::MissingElement("4".into()))?,
+            })
+        }
+    }
+}

--- a/tests/schema/numeric_fields/expected/serde_quick_xml.rs
+++ b/tests/schema/numeric_fields/expected/serde_quick_xml.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+pub type Foo = FooType;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FooType {
+    #[serde(rename = "4")]
+    pub _4: EnumType,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EnumType {
+    #[serde(rename = "1")]
+    _1,
+    #[serde(rename = "2")]
+    _2,
+    #[serde(rename = "3")]
+    _3,
+}

--- a/tests/schema/numeric_fields/expected/serde_xml_rs.rs
+++ b/tests/schema/numeric_fields/expected/serde_xml_rs.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+pub type Foo = FooType;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FooType {
+    #[serde(rename = "4")]
+    pub _4: EnumType,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EnumType {
+    #[serde(rename = "1")]
+    _1,
+    #[serde(rename = "2")]
+    _2,
+    #[serde(rename = "3")]
+    _3,
+}

--- a/tests/schema/numeric_fields/mod.rs
+++ b/tests/schema/numeric_fields/mod.rs
@@ -1,0 +1,123 @@
+use xsd_parser::{generator::SerdeSupport, types::IdentType, Config};
+
+use crate::utils::{generate_test, ConfigEx};
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/schema/numeric_fields/schema.xsd",
+        "tests/schema/numeric_fields/expected/default.rs",
+        Config::test_default().with_generate([(IdentType::Element, "tns:Foo")]),
+    );
+}
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/schema/numeric_fields/schema.xsd",
+        "tests/schema/numeric_fields/expected/quick_xml.rs",
+        Config::test_default()
+            .with_quick_xml()
+            .with_generate([(IdentType::Element, "tns:Foo")]),
+    );
+}
+
+#[test]
+fn generate_serde_xml_rs() {
+    generate_test(
+        "tests/schema/numeric_fields/schema.xsd",
+        "tests/schema/numeric_fields/expected/serde_xml_rs.rs",
+        Config::test_default()
+            .with_serde_support(SerdeSupport::SerdeXmlRs)
+            .with_generate([(IdentType::Element, "tns:Foo")]),
+    );
+}
+
+#[test]
+fn generate_serde_quick_xml() {
+    generate_test(
+        "tests/schema/numeric_fields/schema.xsd",
+        "tests/schema/numeric_fields/expected/serde_quick_xml.rs",
+        Config::test_default()
+            .with_serde_support(SerdeSupport::QuickXml)
+            .with_generate([(IdentType::Element, "tns:Foo")]),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::{EnumType, Foo};
+
+    let obj = crate::utils::quick_xml_read_test::<Foo, _>(
+        "tests/schema/numeric_fields/example/default.xml",
+    );
+
+    assert!(matches!(obj._4, EnumType::_1));
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn write_quick_xml() {
+    use quick_xml::{EnumType, Foo};
+
+    let obj = Foo { _4: EnumType::_1 };
+
+    crate::utils::quick_xml_write_test(
+        &obj,
+        "tns:Foo",
+        "tests/schema/numeric_fields/example/default.xml",
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs() {
+    use serde_xml_rs::{EnumType, Foo};
+
+    let obj = crate::utils::serde_xml_rs_read_test::<Foo, _>(
+        "tests/schema/numeric_fields/example/default.xml",
+    );
+
+    assert!(matches!(obj._4, EnumType::_1));
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_quick_xml() {
+    use serde_quick_xml::{EnumType, Foo};
+
+    let obj = crate::utils::serde_quick_xml_read_test::<Foo, _>(
+        "tests/schema/numeric_fields/example/default.xml",
+    );
+
+    assert!(matches!(obj._4, EnumType::_1));
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_quick_xml.rs");
+}

--- a/tests/schema/numeric_fields/schema.xsd
+++ b/tests/schema/numeric_fields/schema.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://example.com"
+    targetNamespace="http://example.com"
+    elementFormDefault="qualified">
+
+    <xs:simpleType name="EnumType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1" />
+            <xs:enumeration value="2" />
+            <xs:enumeration value="3" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="FooType">
+        <xs:sequence>
+            <!--
+                Numeric field names are officially not allowed,
+                but we still use it for testing purposes here
+            -->
+            <xs:element name="4" type="tns:EnumType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType" />
+</xs:schema>


### PR DESCRIPTION
Having a blanket implementation for the `AsAny` trait reduces size and complexity of the generated code.