### PR TITLE
Implement support for empty complex types

### DIFF
--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -1170,6 +1170,10 @@ impl Deref for ComplexTypeEnum<'_> {
 }
 
 impl ComplexTypeStruct<'_> {
+    pub(super) fn is_unit_struct(&self) -> bool {
+        matches!(&self.mode, StructMode::Empty { .. }) && !self.has_attributes()
+    }
+
     pub(super) fn has_attributes(&self) -> bool {
         !self.attributes.is_empty()
     }

--- a/src/generator/renderer/types.rs
+++ b/src/generator/renderer/types.rs
@@ -264,13 +264,22 @@ impl ComplexTypeStruct<'_> {
         let fields = self.elements().iter().map(|x| x.render_field(ctx));
         let content = self.content().as_ref().and_then(|x| x.render_field(ctx));
 
+        let struct_data = if self.is_unit_struct() {
+            quote!(;)
+        } else {
+            quote! {
+                {
+                    #( #attributes )*
+                    #( #fields )*
+                    #content
+                }
+            }
+        };
+
         let code = quote! {
             #derive
-            pub struct #type_ident {
-                #( #attributes )*
-                #( #fields )*
-                #content
-            }
+            pub struct #type_ident
+                #struct_data
 
             #( #trait_impls )*
         };

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -83,11 +83,12 @@ pub enum Error {
     #[error("Invalid attribute reference: {0:#?}!")]
     InvalidAttributeReference(Box<AttributeType>),
 
-    /// Internal error.
+    /// Unable to create type information.
     ///
-    /// IS raised if an internal error occurred. Check the log output for more details.
-    #[error("Internal error!")]
-    InternalError,
+    /// Is raised if the interpreter was not able to generate a `Type` from the
+    /// provided schema information.
+    #[error("Unable to create type information!")]
+    NoType,
 
     /// The interpreter expected a group type (like `xs:all`, `xs:choice` or `xs:sequence`).
     #[error("Expected group type!")]

--- a/src/interpreter/type_builder.rs
+++ b/src/interpreter/type_builder.rs
@@ -120,7 +120,7 @@ impl<'a, 'schema, 'state> TypeBuilder<'a, 'schema, 'state> {
     }
 
     pub(super) fn finish(self) -> Result<Type, Error> {
-        self.type_.ok_or(Error::InternalError)
+        self.type_.ok_or(Error::NoType)
     }
 
     #[instrument(err, level = "trace", skip(self))]
@@ -285,6 +285,8 @@ impl<'a, 'schema, 'state> TypeBuilder<'a, 'schema, 'state> {
 
         self.type_mode = TypeMode::Complex;
         self.content_mode = ContentMode::Complex;
+
+        get_or_init_any!(self, ComplexType);
 
         for c in &ty.content {
             match c {

--- a/src/schema/occurs.rs
+++ b/src/schema/occurs.rs
@@ -1,7 +1,8 @@
+use std::cmp::Ordering;
 use std::num::ParseIntError;
+use std::ops::AddAssign;
 use std::ops::{Add, Mul, MulAssign};
 use std::str::FromStr;
-use std::{cmp::Ordering, ops::AddAssign};
 
 use serde::{de::Error as DeError, Deserialize, Serialize};
 

--- a/tests/feature/build_in/expected/default.rs
+++ b/tests/feature/build_in/expected/default.rs
@@ -14,7 +14,7 @@ pub type Notationtype = String;
 pub type NameType = String;
 pub type QnameType = String;
 #[derive(Debug, Clone)]
-pub struct AnyType {}
+pub struct AnyType;
 pub type AnyURIType = String;
 pub type Base64BinaryType = String;
 pub type BooleanType = bool;

--- a/tests/feature/build_in/expected/quick_xml.rs
+++ b/tests/feature/build_in/expected/quick_xml.rs
@@ -144,7 +144,7 @@ pub type Notationtype = String;
 pub type NameType = String;
 pub type QnameType = String;
 #[derive(Debug, Clone)]
-pub struct AnyType {}
+pub struct AnyType;
 impl WithSerializer for AnyType {
     type Serializer<'x> = quick_xml_serialize::AnyTypeSerializer<'x>;
     fn serializer<'ser>(

--- a/tests/feature/build_in/expected/serde_quick_xml.rs
+++ b/tests/feature/build_in/expected/serde_quick_xml.rs
@@ -15,7 +15,7 @@ pub type Notationtype = String;
 pub type NameType = String;
 pub type QnameType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnyType {}
+pub struct AnyType;
 pub type AnyURIType = String;
 pub type Base64BinaryType = String;
 pub type BooleanType = bool;

--- a/tests/feature/build_in/expected/serde_xml_rs.rs
+++ b/tests/feature/build_in/expected/serde_xml_rs.rs
@@ -15,7 +15,7 @@ pub type Notationtype = String;
 pub type NameType = String;
 pub type QnameType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnyType {}
+pub struct AnyType;
 pub type AnyURIType = String;
 pub type Base64BinaryType = String;
 pub type BooleanType = bool;

--- a/tests/feature/complex_type_empty/example/default.xml
+++ b/tests/feature/complex_type_empty/example/default.xml
@@ -1,0 +1,1 @@
+<SuccessType />

--- a/tests/feature/complex_type_empty/expected/default.rs
+++ b/tests/feature/complex_type_empty/expected/default.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone)]
+pub struct SuccessType;

--- a/tests/feature/complex_type_empty/expected/quick_xml.rs
+++ b/tests/feature/complex_type_empty/expected/quick_xml.rs
@@ -1,0 +1,150 @@
+pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
+pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
+pub const NS_DEFAULT: Namespace = Namespace::new_const(b"http://www.iata.org/IATA/2007/00");
+use xsd_parser::{
+    quick_xml::{Error, WithDeserializer, WithSerializer},
+    schema::Namespace,
+};
+#[derive(Debug, Clone)]
+pub struct SuccessType;
+impl WithSerializer for SuccessType {
+    type Serializer<'x> = quick_xml_serialize::SuccessTypeSerializer<'x>;
+    fn serializer<'ser>(
+        &'ser self,
+        name: Option<&'ser str>,
+        is_root: bool,
+    ) -> Result<Self::Serializer<'ser>, Error> {
+        Ok(quick_xml_serialize::SuccessTypeSerializer {
+            value: self,
+            state: quick_xml_serialize::SuccessTypeSerializerState::Init__,
+            name: name.unwrap_or("SuccessType"),
+            is_root,
+        })
+    }
+}
+impl WithDeserializer for SuccessType {
+    type Deserializer = quick_xml_deserialize::SuccessTypeDeserializer;
+}
+pub mod quick_xml_serialize {
+    use core::iter::Iterator;
+    use xsd_parser::quick_xml::{BytesStart, Error, Event};
+    #[derive(Debug)]
+    pub struct SuccessTypeSerializer<'ser> {
+        pub(super) value: &'ser super::SuccessType,
+        pub(super) state: SuccessTypeSerializerState<'ser>,
+        pub(super) name: &'ser str,
+        pub(super) is_root: bool,
+    }
+    #[derive(Debug)]
+    pub(super) enum SuccessTypeSerializerState<'ser> {
+        Init__,
+        Done__,
+        Phantom__(&'ser ()),
+    }
+    impl<'ser> SuccessTypeSerializer<'ser> {
+        fn next_event(&mut self) -> Result<Option<Event<'ser>>, Error> {
+            loop {
+                match &mut self.state {
+                    SuccessTypeSerializerState::Init__ => {
+                        self.state = SuccessTypeSerializerState::Done__;
+                        let bytes = BytesStart::new(self.name);
+                        return Ok(Some(Event::Empty(bytes)));
+                    }
+                    SuccessTypeSerializerState::Done__ => return Ok(None),
+                    SuccessTypeSerializerState::Phantom__(_) => unreachable!(),
+                }
+            }
+        }
+    }
+    impl<'ser> Iterator for SuccessTypeSerializer<'ser> {
+        type Item = Result<Event<'ser>, Error>;
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.next_event() {
+                Ok(Some(event)) => Some(Ok(event)),
+                Ok(None) => None,
+                Err(error) => {
+                    self.state = SuccessTypeSerializerState::Done__;
+                    Some(Err(error))
+                }
+            }
+        }
+    }
+}
+pub mod quick_xml_deserialize {
+    use core::mem::replace;
+    use xsd_parser::quick_xml::{
+        filter_xmlns_attributes, BytesStart, DeserializeReader, Deserializer, DeserializerArtifact,
+        DeserializerEvent, DeserializerOutput, DeserializerResult, Error, Event,
+    };
+    #[derive(Debug)]
+    pub struct SuccessTypeDeserializer {
+        state: Box<SuccessTypeDeserializerState>,
+    }
+    #[derive(Debug)]
+    enum SuccessTypeDeserializerState {
+        Init__,
+        Unknown__,
+    }
+    impl SuccessTypeDeserializer {
+        fn from_bytes_start<R>(reader: &R, bytes_start: &BytesStart<'_>) -> Result<Self, Error>
+        where
+            R: DeserializeReader,
+        {
+            for attrib in filter_xmlns_attributes(bytes_start) {
+                let attrib = attrib?;
+                reader.raise_unexpected_attrib(attrib)?;
+            }
+            Ok(Self {
+                state: Box::new(SuccessTypeDeserializerState::Init__),
+            })
+        }
+        fn finish_state<R>(
+            &mut self,
+            reader: &R,
+            state: SuccessTypeDeserializerState,
+        ) -> Result<(), Error>
+        where
+            R: DeserializeReader,
+        {
+            Ok(())
+        }
+    }
+    impl<'de> Deserializer<'de, super::SuccessType> for SuccessTypeDeserializer {
+        fn init<R>(reader: &R, event: Event<'de>) -> DeserializerResult<'de, super::SuccessType>
+        where
+            R: DeserializeReader,
+        {
+            reader.init_deserializer_from_start_event(event, Self::from_bytes_start)
+        }
+        fn next<R>(
+            mut self,
+            reader: &R,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::SuccessType>
+        where
+            R: DeserializeReader,
+        {
+            if let Event::End(_) = &event {
+                Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::Data(self.finish(reader)?),
+                    event: DeserializerEvent::None,
+                    allow_any: false,
+                })
+            } else {
+                Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::Deserializer(self),
+                    event: DeserializerEvent::Break(event),
+                    allow_any: false,
+                })
+            }
+        }
+        fn finish<R>(mut self, reader: &R) -> Result<super::SuccessType, Error>
+        where
+            R: DeserializeReader,
+        {
+            let state = replace(&mut *self.state, SuccessTypeDeserializerState::Unknown__);
+            self.finish_state(reader, state)?;
+            Ok(super::SuccessType {})
+        }
+    }
+}

--- a/tests/feature/complex_type_empty/expected/serde_quick_xml.rs
+++ b/tests/feature/complex_type_empty/expected/serde_quick_xml.rs
@@ -1,0 +1,3 @@
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuccessType;

--- a/tests/feature/complex_type_empty/expected/serde_xml_rs.rs
+++ b/tests/feature/complex_type_empty/expected/serde_xml_rs.rs
@@ -1,0 +1,3 @@
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuccessType;

--- a/tests/feature/complex_type_empty/mod.rs
+++ b/tests/feature/complex_type_empty/mod.rs
@@ -1,0 +1,122 @@
+use xsd_parser::{
+    config::NamespaceIdent, generator::SerdeSupport, schema::Namespace, types::IdentType, Config,
+};
+
+use crate::utils::{generate_test, ConfigEx};
+
+const NS: NamespaceIdent =
+    NamespaceIdent::Namespace(Namespace::new_const(b"http://www.iata.org/IATA/2007/00"));
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/complex_type_empty/schema.xsd",
+        "tests/feature/complex_type_empty/expected/default.rs",
+        Config::test_default().with_generate([(IdentType::Type, Some(NS), "SuccessType")]),
+    );
+}
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/feature/complex_type_empty/schema.xsd",
+        "tests/feature/complex_type_empty/expected/quick_xml.rs",
+        Config::test_default().with_quick_xml().with_generate([(
+            IdentType::Type,
+            Some(NS),
+            "SuccessType",
+        )]),
+    );
+}
+
+#[test]
+fn generate_serde_xml_rs() {
+    generate_test(
+        "tests/feature/complex_type_empty/schema.xsd",
+        "tests/feature/complex_type_empty/expected/serde_xml_rs.rs",
+        Config::test_default()
+            .with_serde_support(SerdeSupport::SerdeXmlRs)
+            .with_generate([(IdentType::Type, Some(NS), "SuccessType")]),
+    );
+}
+
+#[test]
+fn generate_serde_quick_xml() {
+    generate_test(
+        "tests/feature/complex_type_empty/schema.xsd",
+        "tests/feature/complex_type_empty/expected/serde_quick_xml.rs",
+        Config::test_default()
+            .with_serde_support(SerdeSupport::QuickXml)
+            .with_generate([(IdentType::Type, Some(NS), "SuccessType")]),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::SuccessType;
+
+    crate::utils::quick_xml_read_test::<SuccessType, _>(
+        "tests/feature/complex_type_empty/example/default.xml",
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn write_quick_xml() {
+    use quick_xml::SuccessType;
+
+    crate::utils::quick_xml_write_test(
+        &SuccessType {},
+        "SuccessType",
+        "tests/feature/complex_type_empty/example/default.xml",
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs() {
+    use serde_xml_rs::SuccessType;
+
+    crate::utils::serde_xml_rs_read_test::<SuccessType, _>(
+        "tests/feature/complex_type_empty/example/default.xml",
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_quick_xml() {
+    use serde_quick_xml::SuccessType;
+
+    crate::utils::serde_quick_xml_read_test::<SuccessType, _>(
+        "tests/feature/complex_type_empty/example/default.xml",
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_quick_xml.rs");
+}

--- a/tests/feature/complex_type_empty/schema.xsd
+++ b/tests/feature/complex_type_empty/schema.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.iata.org/IATA/2007/00" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.iata.org/IATA/2007/00" elementFormDefault="qualified"
+           version="2.009" id="IATA2021.3">
+    <xs:complexType name="SuccessType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Standard way to indicate successful processing of an IATA message. Returning an empty element of this type indicates success.</xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+</xs:schema>

--- a/tests/feature/mod.rs
+++ b/tests/feature/mod.rs
@@ -5,6 +5,7 @@ mod any;
 mod build_in;
 mod choice;
 mod choice_with_sequence;
+mod complex_type_empty;
 mod complex_type_with_group;
 mod complex_type_with_repeated_content;
 mod dynamic_types;


### PR DESCRIPTION
Empty complex type will be rendered as unit struct from now on.

Related to #13 