### PR TITLE
Default to xs:anyType when element type is not specified in corner cases

### DIFF
--- a/src/pipeline/interpreter/variant_builder.rs
+++ b/src/pipeline/interpreter/variant_builder.rs
@@ -198,6 +198,15 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
 
             if has_content {
                 init_any!(self, Reference, ReferenceMeta::new(type_?), true);
+            } else {
+                // No actual type content found, default to xs:anyType
+                let xs = self
+                    .schemas
+                    .resolve_namespace(&Some(Namespace::XS))
+                    .ok_or_else(|| Error::UnknownNamespace(Namespace::XS.clone()))?;
+                let ident = Ident::ANY_TYPE.with_ns(Some(xs));
+
+                init_any!(self, Reference, ReferenceMeta::new(ident), true);
             }
         } else {
             let xs = self

--- a/tests/feature/element_without_type/example/default.xml
+++ b/tests/feature/element_without_type/example/default.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<my_name>
+    <!-- This element has no explicit type, so it defaults to xs:anyType -->
+    <!-- It can contain any valid XML content -->
+    <some_child_element>Hello World</some_child_element>
+    <another_element attr="value">
+        <nested>Content can be arbitrary</nested>
+    </another_element>
+    <!-- Mixed content is also allowed with anyType -->
+    Some text content
+    <yet_another>42</yet_another>
+    More text
+</my_name>

--- a/tests/feature/element_without_type/expected/default.rs
+++ b/tests/feature/element_without_type/expected/default.rs
@@ -1,0 +1,3 @@
+pub type MyName = AnyType;
+#[derive(Debug)]
+pub struct AnyType;

--- a/tests/feature/element_without_type/expected/quick_xml.rs
+++ b/tests/feature/element_without_type/expected/quick_xml.rs
@@ -1,0 +1,146 @@
+use xsd_parser::{
+    models::schema::Namespace,
+    quick_xml::{Error, WithDeserializer, WithSerializer},
+};
+pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
+pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
+pub type MyName = AnyType;
+#[derive(Debug)]
+pub struct AnyType;
+impl WithSerializer for AnyType {
+    type Serializer<'x> = quick_xml_serialize::AnyTypeSerializer<'x>;
+    fn serializer<'ser>(
+        &'ser self,
+        name: Option<&'ser str>,
+        is_root: bool,
+    ) -> Result<Self::Serializer<'ser>, Error> {
+        Ok(quick_xml_serialize::AnyTypeSerializer {
+            value: self,
+            state: Box::new(quick_xml_serialize::AnyTypeSerializerState::Init__),
+            name: name.unwrap_or("xs:anyType"),
+            is_root,
+        })
+    }
+}
+impl WithDeserializer for AnyType {
+    type Deserializer = quick_xml_deserialize::AnyTypeDeserializer;
+}
+pub mod quick_xml_deserialize {
+    use core::mem::replace;
+    use xsd_parser::quick_xml::{
+        BytesStart, DeserializeReader, Deserializer, DeserializerArtifact, DeserializerEvent,
+        DeserializerOutput, DeserializerResult, Error, Event,
+    };
+    #[derive(Debug)]
+    pub struct AnyTypeDeserializer {
+        state: Box<AnyTypeDeserializerState>,
+    }
+    #[derive(Debug)]
+    enum AnyTypeDeserializerState {
+        Init__,
+        Unknown__,
+    }
+    impl AnyTypeDeserializer {
+        fn from_bytes_start<R>(reader: &R, bytes_start: &BytesStart<'_>) -> Result<Self, Error>
+        where
+            R: DeserializeReader,
+        {
+            Ok(Self {
+                state: Box::new(AnyTypeDeserializerState::Init__),
+            })
+        }
+        fn finish_state<R>(
+            &mut self,
+            reader: &R,
+            state: AnyTypeDeserializerState,
+        ) -> Result<(), Error>
+        where
+            R: DeserializeReader,
+        {
+            Ok(())
+        }
+    }
+    impl<'de> Deserializer<'de, super::AnyType> for AnyTypeDeserializer {
+        fn init<R>(reader: &R, event: Event<'de>) -> DeserializerResult<'de, super::AnyType>
+        where
+            R: DeserializeReader,
+        {
+            reader.init_deserializer_from_start_event(event, Self::from_bytes_start)
+        }
+        fn next<R>(
+            mut self,
+            reader: &R,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::AnyType>
+        where
+            R: DeserializeReader,
+        {
+            if let Event::End(_) = &event {
+                Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::Data(self.finish(reader)?),
+                    event: DeserializerEvent::None,
+                    allow_any: false,
+                })
+            } else {
+                Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::Deserializer(self),
+                    event: DeserializerEvent::Break(event),
+                    allow_any: true,
+                })
+            }
+        }
+        fn finish<R>(mut self, reader: &R) -> Result<super::AnyType, Error>
+        where
+            R: DeserializeReader,
+        {
+            let state = replace(&mut *self.state, AnyTypeDeserializerState::Unknown__);
+            self.finish_state(reader, state)?;
+            Ok(super::AnyType {})
+        }
+    }
+}
+pub mod quick_xml_serialize {
+    use core::iter::Iterator;
+    use xsd_parser::quick_xml::{BytesStart, Error, Event};
+    #[derive(Debug)]
+    pub struct AnyTypeSerializer<'ser> {
+        pub(super) value: &'ser super::AnyType,
+        pub(super) state: Box<AnyTypeSerializerState<'ser>>,
+        pub(super) name: &'ser str,
+        pub(super) is_root: bool,
+    }
+    #[derive(Debug)]
+    pub(super) enum AnyTypeSerializerState<'ser> {
+        Init__,
+        Done__,
+        Phantom__(&'ser ()),
+    }
+    impl<'ser> AnyTypeSerializer<'ser> {
+        fn next_event(&mut self) -> Result<Option<Event<'ser>>, Error> {
+            loop {
+                match &mut *self.state {
+                    AnyTypeSerializerState::Init__ => {
+                        *self.state = AnyTypeSerializerState::Done__;
+                        let bytes = BytesStart::new(self.name);
+                        return Ok(Some(Event::Empty(bytes)));
+                    }
+                    AnyTypeSerializerState::Done__ => return Ok(None),
+                    AnyTypeSerializerState::Phantom__(_) => unreachable!(),
+                }
+            }
+        }
+    }
+    impl<'ser> Iterator for AnyTypeSerializer<'ser> {
+        type Item = Result<Event<'ser>, Error>;
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.next_event() {
+                Ok(Some(event)) => Some(Ok(event)),
+                Ok(None) => None,
+                Err(error) => {
+                    *self.state = AnyTypeSerializerState::Done__;
+                    Some(Err(error))
+                }
+            }
+        }
+    }
+}

--- a/tests/feature/element_without_type/mod.rs
+++ b/tests/feature/element_without_type/mod.rs
@@ -1,0 +1,51 @@
+use xsd_parser::{config::InterpreterFlags, Config, IdentType};
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default()
+        .with_interpreter_flags(InterpreterFlags::all())
+        .with_generate([(IdentType::Element, "xml:my_name")])
+}
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/element_without_type/schema.xsd",
+        "tests/feature/element_without_type/expected/default.rs",
+        config(),
+    );
+}
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/feature/element_without_type/schema.xsd",
+        "tests/feature/element_without_type/expected/quick_xml.rs",
+        config().with_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::MyName;
+
+    let obj = crate::utils::quick_xml_read_test::<MyName, _>(
+        "tests/feature/element_without_type/example/default.xml",
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}

--- a/tests/feature/element_without_type/schema.xsd
+++ b/tests/feature/element_without_type/schema.xsd
@@ -1,0 +1,11 @@
+<?xml version='1.0'?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+ <xs:element name="my_name">
+	<xs:annotation>
+		<xs:documentation>Some documentation</xs:documentation>
+	</xs:annotation>
+</xs:element>
+</xs:schema>

--- a/tests/feature/mod.rs
+++ b/tests/feature/mod.rs
@@ -10,6 +10,7 @@ mod complex_type_with_group;
 mod complex_type_with_repeated_content;
 mod documentation;
 mod dynamic_types;
+mod element_without_type;
 mod enumeration;
 mod enumeration_with_annotation;
 mod extension_base;


### PR DESCRIPTION
Fixes #86. Additions:
- VariantBuilder::apply_element applies xs:anyType if the `ElementType.content` does not contain a SimpleType or ComplexType and no other type is specified.
- Tests to ensure anyType is applied in these situations. 
