### PR TITLE
Add support for `anySimpleType` and fix interpreter bug

### DIFF
--- a/src/pipeline/interpreter/mod.rs
+++ b/src/pipeline/interpreter/mod.rs
@@ -201,7 +201,7 @@ impl<'a> Interpreter<'a> {
         add!(xs, "gMonth", STRING);
         add!(xs, "gDay", STRING);
 
-        /* Date related types */
+        /* Data related types */
 
         add!(xs, "hexBinary", STRING);
         add!(xs, "base64Binary", STRING);
@@ -239,6 +239,8 @@ impl<'a> Interpreter<'a> {
         add!(xs, "NCName", STRING);
         add!(xs, "ID", STRING);
         add!(xs, "IDREF", STRING);
+
+        add!(xs, "anySimpleType", STRING);
 
         add_list!(xs, "NMTOKENS", STRING);
         add_list!(xs, "IDREFS", STRING);

--- a/src/pipeline/interpreter/variant_builder.rs
+++ b/src/pipeline/interpreter/variant_builder.rs
@@ -278,7 +278,10 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
     pub(super) fn apply_simple_type(&mut self, ty: &SimpleBaseType) -> Result<(), Error> {
         use crate::models::schema::xs::SimpleBaseTypeContent as C;
 
-        self.type_mode = TypeMode::Simple;
+        if self.type_mode == TypeMode::Unknown {
+            self.type_mode = TypeMode::Simple;
+        }
+
         self.content_mode = ContentMode::Simple;
 
         for c in &ty.content {
@@ -996,8 +999,6 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
             (_, _) => crate::unreachable!("Unset or invalid combination!"),
         };
 
-        tracing::debug!("{base:#?}");
-
         let mut base = base.clone();
 
         match (self.content_mode, &mut base) {
@@ -1044,8 +1045,6 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
             }
             (_, _, _) => crate::unreachable!("Unset or invalid combination!"),
         }
-
-        tracing::debug!("{:#?}", self.variant);
 
         Ok(())
     }

--- a/tests/feature/build_in/expected/default.rs
+++ b/tests/feature/build_in/expected/default.rs
@@ -13,6 +13,7 @@ pub struct NmtokensType(pub Vec<String>);
 pub type NotationType = String;
 pub type NameType = String;
 pub type QNameType = String;
+pub type AnySimpleType = String;
 #[derive(Debug)]
 pub struct AnyType;
 pub type AnyUriType = String;

--- a/tests/feature/build_in/expected/quick_xml.rs
+++ b/tests/feature/build_in/expected/quick_xml.rs
@@ -143,6 +143,7 @@ impl DeserializeBytes for NmtokensType {
 pub type NotationType = String;
 pub type NameType = String;
 pub type QNameType = String;
+pub type AnySimpleType = String;
 #[derive(Debug)]
 pub struct AnyType;
 impl WithSerializer for AnyType {

--- a/tests/feature/build_in/expected/serde_quick_xml.rs
+++ b/tests/feature/build_in/expected/serde_quick_xml.rs
@@ -14,6 +14,7 @@ pub struct NmtokensType(pub Vec<String>);
 pub type NotationType = String;
 pub type NameType = String;
 pub type QNameType = String;
+pub type AnySimpleType = String;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AnyType;
 pub type AnyUriType = String;

--- a/tests/feature/build_in/expected/serde_xml_rs.rs
+++ b/tests/feature/build_in/expected/serde_xml_rs.rs
@@ -14,6 +14,7 @@ pub struct NmtokensType(pub Vec<String>);
 pub type NotationType = String;
 pub type NameType = String;
 pub type QNameType = String;
+pub type AnySimpleType = String;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AnyType;
 pub type AnyUriType = String;

--- a/tests/schema/xml_catalogs/expected/default.rs
+++ b/tests/schema/xml_catalogs/expected/default.rs
@@ -140,6 +140,7 @@ pub mod xs {
     pub type NotationType = String;
     pub type NameType = String;
     pub type QNameType = String;
+    pub type AnySimpleType = String;
     #[derive(Debug)]
     pub struct AnyType;
     pub type AnyUriType = String;

--- a/tests/schema/xml_catalogs/expected/quick_xml.rs
+++ b/tests/schema/xml_catalogs/expected/quick_xml.rs
@@ -6033,6 +6033,7 @@ pub mod xs {
     pub type NotationType = String;
     pub type NameType = String;
     pub type QNameType = String;
+    pub type AnySimpleType = String;
     #[derive(Debug)]
     pub struct AnyType;
     impl WithSerializer for AnyType {

--- a/tests/schema/xml_catalogs/expected/serde_quick_xml.rs
+++ b/tests/schema/xml_catalogs/expected/serde_quick_xml.rs
@@ -205,6 +205,7 @@ pub mod xs {
     pub type NotationType = String;
     pub type NameType = String;
     pub type QNameType = String;
+    pub type AnySimpleType = String;
     #[derive(Debug, Serialize, Deserialize)]
     pub struct AnyType;
     pub type AnyUriType = String;

--- a/tests/schema/xml_catalogs/expected/serde_xml_rs.rs
+++ b/tests/schema/xml_catalogs/expected/serde_xml_rs.rs
@@ -232,6 +232,7 @@ pub mod xs {
     pub type NotationType = String;
     pub type NameType = String;
     pub type QNameType = String;
+    pub type AnySimpleType = String;
     #[derive(Debug, Serialize, Deserialize)]
     pub struct AnyType;
     pub type AnyUriType = String;


### PR DESCRIPTION
The interpreter had an bug, that caused complex types with simple content to be interpreted as simple types, which resulted in a panic, because the interpretation of the simple type then tried to change the fixed variant of the builder. To fix that we set the type mode to simple only if it is not known yet, this will then clone the content type for manipulation in a later code path.