### PR TITLE
Fix deserialization of `bool` values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
  "tracing-subscriber",
  "unindent",
  "url",
+ "xsd-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ encoding_rs = "0.8"
 futures = "0.3"
 indexmap = "2.9"
 Inflector = "0.11"
+num = { version = "0.4", optional = true }
 parking_lot = "0.12"
 proc-macro2 = "1.0"
 quick-xml = { version = "0.38", features = [ "async-tokio", "encoding", "serialize" ] }
@@ -42,11 +43,11 @@ url = "2.5"
 
 [dev-dependencies]
 clap = { version = "4.5", features = [ "derive" ] }
-num = "0.4"
 serde-xml-rs = "0.8"
 serde-xml-rs-v7 = { package = "serde-xml-rs", version = "0.7" }
 text-diff = "0.4"
 tracing-subscriber = { version = "0.3", features = [ "std", "env-filter", "json", "tracing-log" ] }
+xsd-parser = { path = ".", features = [ "num" ] }
 
 [build-dependencies]
 base64 = "0.22"

--- a/src/models/schema/occurs.rs
+++ b/src/models/schema/occurs.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 
 use serde::{de::Error as DeError, Deserialize, Serialize};
 
+use crate::quick_xml::DeserializeBytesFromStr;
+
 /// Represents the minimum occurrence of types or elements
 pub type MinOccurs = usize;
 
@@ -131,3 +133,5 @@ impl<'de> Deserialize<'de> for MaxOccurs {
         }
     }
 }
+
+impl DeserializeBytesFromStr for MaxOccurs {}

--- a/src/quick_xml/mod.rs
+++ b/src/quick_xml/mod.rs
@@ -20,15 +20,15 @@ pub use crate::models::RawByteStr;
 
 pub use self::attributes::{filter_xmlns_attributes, write_attrib, write_attrib_opt};
 pub use self::deserialize::{
-    ContentDeserializer, DeserializeBytes, DeserializeReader, DeserializeStrError, DeserializeSync,
-    Deserializer, DeserializerArtifact, DeserializerEvent, DeserializerOutput, DeserializerResult,
-    ElementHandlerOutput, WithDeserializer,
+    ContentDeserializer, DeserializeBytes, DeserializeBytesFromStr, DeserializeReader,
+    DeserializeStrError, DeserializeSync, Deserializer, DeserializerArtifact, DeserializerEvent,
+    DeserializerOutput, DeserializerResult, ElementHandlerOutput, WithDeserializer,
 };
 pub use self::error::{Error, Kind as ErrorKind, UnionError};
 pub use self::reader::{ErrorReader, IoReader, SliceReader, XmlReader, XmlReaderSync};
 pub use self::serialize::{
-    BoxedSerializer, ContentSerializer, IterSerializer, SerializeBytes, SerializeSync, Serializer,
-    WithBoxedSerializer, WithSerializer,
+    BoxedSerializer, ContentSerializer, IterSerializer, SerializeBytes, SerializeBytesToString,
+    SerializeSync, Serializer, WithBoxedSerializer, WithSerializer,
 };
 
 #[cfg(feature = "async")]

--- a/src/quick_xml/serialize.rs
+++ b/src/quick_xml/serialize.rs
@@ -175,14 +175,42 @@ pub trait SerializeBytes: Sized {
     fn serialize_bytes(&self) -> Result<Option<Cow<'_, str>>, Error>;
 }
 
+/// Marker trait used to automatically implement [`SerializeBytes`] for any type
+/// that implements [`ToString`].
+pub trait SerializeBytesToString: ToString {}
+
 impl<X> SerializeBytes for X
 where
-    X: ToString,
+    X: SerializeBytesToString,
 {
     fn serialize_bytes(&self) -> Result<Option<Cow<'_, str>>, Error> {
         Ok(Some(Cow::Owned(self.to_string())))
     }
 }
+
+impl SerializeBytesToString for bool {}
+impl SerializeBytesToString for String {}
+
+impl SerializeBytesToString for u8 {}
+impl SerializeBytesToString for u16 {}
+impl SerializeBytesToString for u32 {}
+impl SerializeBytesToString for u64 {}
+impl SerializeBytesToString for usize {}
+
+impl SerializeBytesToString for i8 {}
+impl SerializeBytesToString for i16 {}
+impl SerializeBytesToString for i32 {}
+impl SerializeBytesToString for i64 {}
+impl SerializeBytesToString for isize {}
+
+impl SerializeBytesToString for f32 {}
+impl SerializeBytesToString for f64 {}
+
+#[cfg(feature = "num")]
+impl SerializeBytesToString for num::BigInt {}
+
+#[cfg(feature = "num")]
+impl SerializeBytesToString for num::BigUint {}
 
 /// Implements a [`Serializer`] for any type that implements [`SerializeBytes`].
 

--- a/tests/optimizer/abstract.xsd
+++ b/tests/optimizer/abstract.xsd
@@ -3,7 +3,7 @@
     xmlns:tns="http://example.com"
     targetNamespace="http://example.com">
 
-    <xs:element name="Abstract" abstract="true" />
+    <xs:element name="Abstract" abstract="1" />
 
     <xs:element name="First" substitutionGroup="tns:Abstract">
         <xs:complexType>


### PR DESCRIPTION
According to the XML specification boolean values can be `true` or `false`, but also `1` or `0`. This caused an error in the deserialization because we used the `FromStr` implementation of `bool` to deserialize the value.

Any type that implemented `FromStr` automatically got an blanked implementation for `DeserializeBytes`. To solve the issue with custom values, we moved the blanked implementation to a new `DeserializeBytesFromStr` marker trait, a types needs to be marked with to use the `FromStr` implementation and then implemented `DeserializeBytes` for `bool` manually

The changes were also applied analog to `SerializeBytes`, `ToString` and `SerializeBytesToString`.

Related to #91 