### PR TITLE
Fix schema generation and generated type usings

### DIFF
--- a/examples/custom_renderer.rs
+++ b/examples/custom_renderer.rs
@@ -168,7 +168,7 @@ impl CustomRenderStep {
             return;
         };
 
-        ctx.module().usings([include]);
+        ctx.add_usings([include]);
     }
 
     /* Union */

--- a/examples/update_schema.rs
+++ b/examples/update_schema.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     // it defaults to schema/XMLSchema.xsd.
     let output = match args.next() {
         Some(output) => PathBuf::from(output),
-        None => cwd.join("src/schema/xs_generated_new.rs"),
+        None => cwd.join("src/models/schema/xs_generated_new.rs"),
     };
 
     tracing::info!("Generate Code for {input:#?} to {output:#?}");
@@ -74,19 +74,23 @@ fn main() -> Result<(), Error> {
     config.interpreter.types = vec![
         (
             IdentTriple::from((IdentType::Type, "xs:allNNI")),
-            MetaType::from(CustomMeta::new("MaxOccurs").with_default(max_occurs_default)),
+            MetaType::from(
+                CustomMeta::new("MaxOccurs")
+                    .include_from("crate::models::schema::MaxOccurs")
+                    .with_default(max_occurs_default),
+            ),
         ),
         (
             IdentTriple::from((IdentType::Type, "xs:QName")),
-            MetaType::from(CustomMeta::new("QName")),
+            MetaType::from(CustomMeta::new("QName").include_from("crate::models::schema::QName")),
         ),
         (
             IdentTriple::from((IdentType::Element, "xs:appinfo")),
-            MetaType::from(CustomMeta::new("AnyElement")),
+            MetaType::from(CustomMeta::new("AnyElement").include_from("crate::xml::AnyElement")),
         ),
         (
             IdentTriple::from((IdentType::Element, "xs:documentation")),
-            MetaType::from(CustomMeta::new("AnyElement")),
+            MetaType::from(CustomMeta::new("AnyElement").include_from("crate::xml::AnyElement")),
         ),
     ];
 
@@ -107,8 +111,10 @@ fn main() -> Result<(), Error> {
         GeneratorFlags::all() - GeneratorFlags::USE_MODULES - GeneratorFlags::MIXED_TYPE_SUPPORT;
     config.generator.type_postfix.element = String::default();
     config.generator.type_postfix.element_type = String::default();
-    config.generator.generate =
-        Generate::Types(vec![IdentTriple::from((IdentType::Element, "xs:schema"))]);
+    config.generator.generate = Generate::Types(vec![IdentTriple::from((
+        IdentType::ElementType,
+        "xs:schema",
+    ))]);
     config.renderer.xsd_parser = "crate".into();
     config.renderer.derive = Some(
         ["Debug", "Clone", "Eq", "PartialEq"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ pub fn exec_render(config: RendererConfig, types: &DataTypes<'_>) -> Result<Modu
             }
             RenderStep::Defaults => renderer = renderer.with_step(DefaultsRenderStep),
             RenderStep::NamespaceConstants => {
-                renderer = renderer.with_step(NamespaceConstantsRenderStep);
+                renderer = renderer.with_step(NamespaceConstantsRenderStep::default());
             }
             RenderStep::WithNamespaceTrait => {
                 renderer = renderer.with_step(WithNamespaceTraitRenderStep);

--- a/src/models/code/ident_path.rs
+++ b/src/models/code/ident_path.rs
@@ -90,6 +90,12 @@ impl IdentPath {
         &self.ident
     }
 
+    /// Returns the module path for this identifier path.
+    #[must_use]
+    pub fn module(&self) -> Option<&ModulePath> {
+        self.path.as_ref()
+    }
+
     /// Creates a [`TokenStream`] that is relative to the passed `dst` module path.
     ///
     /// This uses the `super` keyword to create a relative path from the passed `dst` module path

--- a/src/models/data/path_data.rs
+++ b/src/models/data/path_data.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use smallvec::{smallvec, SmallVec};
@@ -47,6 +49,19 @@ impl PathData {
         self
     }
 
+    /// Make the path data to an included path data instead of a absolute one.
+    #[must_use]
+    pub fn into_included(self) -> Self {
+        if self.path.module().is_some() {
+            let using = format!("{}", &self.path);
+            let (ident, _) = self.path.into_parts();
+
+            Self::from_path(IdentPath::from_ident(ident)).with_using(using)
+        } else {
+            self
+        }
+    }
+
     /// Resolves the target type relative to the passed module `path` and
     /// returns the rendered type as [`TokenStream`].
     #[must_use]
@@ -64,5 +79,13 @@ impl PathData {
         }
 
         ret
+    }
+}
+
+impl Deref for PathData {
+    type Target = IdentPath;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
     }
 }

--- a/src/models/schema/xs.rs
+++ b/src/models/schema/xs.rs
@@ -20,9 +20,6 @@ use quick_xml::{events::Event, Writer};
 use unindent::unindent;
 
 use crate::quick_xml::WithSerializer;
-use crate::xml::AnyElement;
-
-use super::{MaxOccurs, QName};
 
 pub type Use = AttributeUseType;
 

--- a/src/pipeline/generator/data/reference.rs
+++ b/src/pipeline/generator/data/reference.rs
@@ -1,5 +1,4 @@
 use crate::config::TypedefMode;
-use crate::models::data::PathData;
 use crate::models::{
     data::{Occurs, ReferenceData},
     meta::ReferenceMeta,
@@ -13,12 +12,10 @@ impl<'types> ReferenceData<'types> {
         ctx: &mut Context<'_, 'types>,
     ) -> Result<Self, Error> {
         let occurs = Occurs::from_occurs(meta.min_occurs, meta.max_occurs);
-        let type_ident = ctx.current_type_ref().type_ident.clone();
+        let type_ident = ctx.current_type_ref().path.ident().clone();
 
         let target_ref = ctx.get_or_create_type_ref(&meta.type_)?;
-
-        let target_type = target_ref.to_ident_path();
-        let target_type = PathData::from_path(target_type);
+        let target_type = target_ref.path.clone();
 
         let trait_impls = ctx.make_trait_impls()?;
 

--- a/src/pipeline/generator/data/union.rs
+++ b/src/pipeline/generator/data/union.rs
@@ -2,7 +2,7 @@ use proc_macro2::Literal;
 
 use crate::models::{
     code::format_variant_ident,
-    data::{PathData, UnionData, UnionTypeVariant},
+    data::{UnionData, UnionTypeVariant},
     meta::{UnionMeta, UnionMetaType},
 };
 
@@ -13,7 +13,7 @@ impl<'types> UnionData<'types> {
         meta: &'types UnionMeta,
         ctx: &mut Context<'_, 'types>,
     ) -> Result<Self, Error> {
-        let type_ident = ctx.current_type_ref().type_ident.clone();
+        let type_ident = ctx.current_type_ref().path.ident().clone();
         let trait_impls = ctx.make_trait_impls()?;
         let variants = meta
             .types
@@ -39,10 +39,7 @@ impl UnionMetaType {
         let b_name = Literal::byte_string(s_name.as_bytes());
 
         let type_ref = ctx.get_or_create_type_ref(&self.type_)?;
-
-        let target_type = type_ref.to_ident_path();
-        let target_type = PathData::from_path(target_type);
-
+        let target_type = type_ref.path.clone();
         let variant_ident = format_variant_ident(&self.type_.name, self.display_name.as_deref());
 
         Ok(UnionTypeVariant {

--- a/src/pipeline/generator/state.rs
+++ b/src/pipeline/generator/state.rs
@@ -1,10 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::ops::Deref;
 
-use proc_macro2::Ident as Ident2;
-
 use crate::models::{
-    code::IdentPath,
+    data::PathData,
     meta::{DynamicMeta, MetaType, MetaTypeVariant, MetaTypes},
     Ident,
 };
@@ -30,20 +28,8 @@ pub(super) struct PendingType<'types> {
 
 #[derive(Debug)]
 pub(super) struct TypeRef {
-    pub ident: Ident,
-    pub type_ident: Ident2,
-    pub module_ident: Option<Ident2>,
+    pub path: PathData,
     pub boxed_elements: HashSet<Ident>,
-}
-
-impl TypeRef {
-    pub(super) fn to_ident_path(&self) -> IdentPath {
-        if self.ident.is_build_in() {
-            IdentPath::from_ident(self.type_ident.clone())
-        } else {
-            IdentPath::from_ident(self.type_ident.clone()).with_path(self.module_ident.clone())
-        }
-    }
 }
 
 /* TraitInfos */

--- a/src/pipeline/interpreter/name_builder.rs
+++ b/src/pipeline/interpreter/name_builder.rs
@@ -5,14 +5,16 @@ use super::state::{StackEntry, State};
 impl NameBuilder {
     pub(super) fn auto_extend(
         self,
-        stop_at_named_group: bool,
+        stop_at_group_ref: bool,
         replace: bool,
         state: &mut State<'_>,
     ) -> Self {
         for x in state.type_stack.iter().rev() {
             match x {
                 StackEntry::Type(x, _) => return self.extend(replace, Some(x.name.as_str())),
-                StackEntry::NamedGroup(_) if stop_at_named_group => break,
+                StackEntry::GroupRef(_) | StackEntry::AttributeGroupRef if stop_at_group_ref => {
+                    break
+                }
                 _ => (),
             }
         }

--- a/src/pipeline/renderer/context.rs
+++ b/src/pipeline/renderer/context.rs
@@ -63,6 +63,16 @@ impl<'a, 'types> Context<'a, 'types> {
         Self::main_module(self.module_path.last(), &mut root).usings(usings);
     }
 
+    /// Add using directives to the root module.
+    pub fn add_root_usings<I>(&self, usings: I)
+    where
+        I: IntoIterator,
+        I::Item: ToString,
+    {
+        let usings = self.patch_usings(usings);
+        self.module.lock().usings(usings);
+    }
+
     /// Returns a mutable reference to the module of the current rendered type.
     pub fn module(&mut self) -> &mut Module {
         let root = self.module.get_mut();

--- a/src/pipeline/renderer/steps/quick_xml/deserialize.rs
+++ b/src/pipeline/renderer/steps/quick_xml/deserialize.rs
@@ -71,12 +71,13 @@ impl UnionData<'_> {
             .iter()
             .map(|var| var.render_deserializer_variant(ctx));
 
-        let usings = [
+        ctx.add_usings([
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::ErrorKind",
             "xsd_parser::quick_xml::DeserializeBytes",
             "xsd_parser::quick_xml::XmlReader",
-        ];
+        ]);
+
         let code = quote! {
             impl DeserializeBytes for #type_ident {
                 fn deserialize_bytes<R>(
@@ -95,7 +96,7 @@ impl UnionData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -141,14 +142,15 @@ impl DynamicData<'_> {
             quote!(quick_xml_deserialize::#deserializer_ident)
         };
 
-        let usings = ["xsd_parser::quick_xml::WithDeserializer"];
+        ctx.add_usings(["xsd_parser::quick_xml::WithDeserializer"]);
+
         let code = quote! {
             impl WithDeserializer for #type_ident {
                 type Deserializer = #deserializer_type;
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 
     fn render_deserializer_types(&self, ctx: &mut Context<'_, '_>) {
@@ -167,7 +169,8 @@ impl DynamicData<'_> {
             }
         });
 
-        let usings = ["xsd_parser::quick_xml::WithDeserializer"];
+        ctx.add_quick_xml_deserialize_usings(["xsd_parser::quick_xml::WithDeserializer"]);
+
         let code = quote! {
             #[derive(Debug)]
             pub enum #deserializer_ident {
@@ -175,7 +178,7 @@ impl DynamicData<'_> {
             }
         };
 
-        ctx.quick_xml_deserialize().usings(usings).append(code);
+        ctx.quick_xml_deserialize().append(code);
     }
 
     fn render_deserializer_impls(&self, ctx: &mut Context<'_, '_>) {
@@ -210,7 +213,7 @@ impl DynamicData<'_> {
             }
         });
 
-        let usings = [
+        ctx.add_quick_xml_deserialize_usings([
             "xsd_parser::quick_xml::Event",
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::Deserializer",
@@ -219,7 +222,8 @@ impl DynamicData<'_> {
             "xsd_parser::quick_xml::DeserializerResult",
             "xsd_parser::quick_xml::DeserializerOutput",
             "xsd_parser::quick_xml::DeserializerArtifact",
-        ];
+        ]);
+
         let code = quote! {
             impl<'de> Deserializer<'de, super::#type_ident> for #deserializer_type {
                 fn init<R>(
@@ -274,7 +278,7 @@ impl DynamicData<'_> {
             }
         };
 
-        ctx.quick_xml_deserialize().usings(usings).append(code);
+        ctx.quick_xml_deserialize().append(code);
     }
 }
 
@@ -457,11 +461,12 @@ impl ReferenceData<'_> {
             }
         };
 
-        let usings = [
+        ctx.add_usings([
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::DeserializeBytes",
             "xsd_parser::quick_xml::DeserializeReader",
-        ];
+        ]);
+
         let code = quote! {
             impl DeserializeBytes for #type_ident {
                 fn deserialize_bytes<R>(
@@ -476,7 +481,7 @@ impl ReferenceData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -513,11 +518,12 @@ impl EnumerationData<'_> {
             }
         });
 
-        let usings = [
+        ctx.add_usings([
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::DeserializeBytes",
             "xsd_parser::quick_xml::DeserializeReader",
-        ];
+        ]);
+
         let code = quote! {
             impl DeserializeBytes for #type_ident {
                 fn deserialize_bytes<R>(
@@ -535,7 +541,7 @@ impl EnumerationData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -622,14 +628,15 @@ impl ComplexBase {
             quote!(quick_xml_deserialize::#deserializer_ident)
         };
 
-        let usings = ["xsd_parser::quick_xml::WithDeserializer"];
+        ctx.add_usings(["xsd_parser::quick_xml::WithDeserializer"]);
+
         let code = quote! {
             impl WithDeserializer for #type_ident {
                 type Deserializer = #deserializer_type;
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 
     fn render_deserializer_impl(
@@ -650,13 +657,13 @@ impl ComplexBase {
         };
         let mut_ = finish_mut_self.then(|| quote!(mut));
 
-        let usings = [
+        ctx.add_quick_xml_deserialize_usings([
             "xsd_parser::quick_xml::Event",
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::Deserializer",
             "xsd_parser::quick_xml::DeserializeReader",
             "xsd_parser::quick_xml::DeserializerResult",
-        ];
+        ]);
 
         let code = quote! {
             impl<'de> Deserializer<'de, super::#type_ident> for #deserializer_type {
@@ -690,7 +697,7 @@ impl ComplexBase {
             }
         };
 
-        ctx.quick_xml_deserialize().usings(usings).append(code);
+        ctx.quick_xml_deserialize().append(code);
     }
 
     fn render_deserializer_fn_init_for_element(&self, ctx: &Context<'_, '_>) -> TokenStream {
@@ -1191,6 +1198,8 @@ impl ComplexDataStruct<'_> {
             }
         };
 
+        ctx.add_quick_xml_deserialize_usings(use_with_deserializer);
+
         let code = quote! {
             #[derive(Debug)]
             enum #deserializer_state_ident {
@@ -1198,9 +1207,7 @@ impl ComplexDataStruct<'_> {
             }
         };
 
-        ctx.quick_xml_deserialize()
-            .usings(use_with_deserializer)
-            .append(code);
+        ctx.quick_xml_deserialize().append(code);
     }
 
     fn render_deserializer_helper(&self, ctx: &mut Context<'_, '_>) {

--- a/src/pipeline/renderer/steps/quick_xml/serialize.rs
+++ b/src/pipeline/renderer/steps/quick_xml/serialize.rs
@@ -57,11 +57,12 @@ impl UnionData<'_> {
             .map(UnionTypeVariant::render_serializer_variant)
             .collect::<Vec<_>>();
 
-        let usings = [
+        ctx.add_usings([
             "std::borrow::Cow",
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::SerializeBytes",
-        ];
+        ]);
+
         let code = quote! {
             impl SerializeBytes for #type_ident {
                 fn serialize_bytes(&self) -> Result<Option<Cow<'_, str>>, Error> {
@@ -72,7 +73,7 @@ impl UnionData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -92,11 +93,12 @@ impl DynamicData<'_> {
     pub(crate) fn render_serializer(&self, ctx: &mut Context<'_, '_>) {
         let Self { type_ident, .. } = self;
 
-        let usings = [
+        ctx.add_usings([
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::WithSerializer",
             "xsd_parser::quick_xml::BoxedSerializer",
-        ];
+        ]);
+
         let code = quote! {
             impl WithSerializer for #type_ident {
                 type Serializer<'x> = BoxedSerializer<'x>;
@@ -113,7 +115,7 @@ impl DynamicData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -170,11 +172,12 @@ impl ReferenceData<'_> {
             }
         };
 
-        let usings = [
+        ctx.add_usings([
             "std::borrow::Cow",
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::SerializeBytes",
-        ];
+        ]);
+
         let code = quote! {
             impl SerializeBytes for #type_ident {
                 fn serialize_bytes(&self) -> Result<Option<Cow<'_, str>>, Error> {
@@ -183,7 +186,7 @@ impl ReferenceData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -201,11 +204,12 @@ impl EnumerationData<'_> {
             .iter()
             .map(EnumerationTypeVariant::render_serializer_variant);
 
-        let usings = [
+        ctx.add_usings([
             "std::borrow::Cow",
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::SerializeBytes",
-        ];
+        ]);
+
         let code = quote! {
             impl SerializeBytes for #type_ident {
                 fn serialize_bytes(&self) -> Result<Option<Cow<'_, str>>, Error> {
@@ -216,7 +220,7 @@ impl EnumerationData<'_> {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 }
 
@@ -284,10 +288,11 @@ impl ComplexBase {
             self.render_with_serializer_for_content()
         };
 
-        let usings = [
+        ctx.add_usings([
             "xsd_parser::quick_xml::Error",
             "xsd_parser::quick_xml::WithSerializer",
-        ];
+        ]);
+
         let code = quote! {
             impl WithSerializer for #type_ident {
                 type Serializer<'x> = quick_xml_serialize::#serializer_ident<'x>;
@@ -302,7 +307,7 @@ impl ComplexBase {
             }
         };
 
-        ctx.module().usings(usings).append(code);
+        ctx.module().append(code);
     }
 
     fn render_with_serializer_for_element(&self, tag_name: &str) -> TokenStream {
@@ -503,11 +508,12 @@ impl ComplexDataEnum<'_> {
             .serializer_need_end_state()
             .then(|| self.render_serializer_handle_state_end(ctx));
 
-        let usings = [
+        ctx.add_quick_xml_serialize_usings([
             "core::iter::Iterator",
             "xsd_parser::quick_xml::Event",
             "xsd_parser::quick_xml::Error",
-        ];
+        ]);
+
         let code = quote! {
             impl<'ser> #serializer_ident<'ser> {
                 fn next_event(&mut self) -> Result<Option<Event<'ser>>, Error> {
@@ -543,7 +549,7 @@ impl ComplexDataEnum<'_> {
             }
         };
 
-        ctx.quick_xml_serialize().usings(usings).append(code);
+        ctx.quick_xml_serialize().append(code);
     }
 
     fn render_serializer_impl_start_event(&self, ctx: &Context<'_, '_>) -> TokenStream {
@@ -676,11 +682,12 @@ impl ComplexDataStruct<'_> {
             .serializer_need_end_state()
             .then(|| self.render_serializer_handle_state_end(ctx));
 
-        let usings = [
+        ctx.add_quick_xml_serialize_usings([
             "core::iter::Iterator",
             "xsd_parser::quick_xml::Event",
             "xsd_parser::quick_xml::Error",
-        ];
+        ]);
+
         let code = quote! {
             impl<'ser> #serializer_ident<'ser> {
                 fn next_event(&mut self) -> Result<Option<Event<'ser>>, Error>
@@ -718,7 +725,7 @@ impl ComplexDataStruct<'_> {
             }
         };
 
-        ctx.quick_xml_serialize().usings(usings).append(code);
+        ctx.quick_xml_serialize().append(code);
     }
 
     fn render_serializer_impl_start_event(&self, ctx: &Context<'_, '_>) -> TokenStream {

--- a/src/pipeline/renderer/steps/serde/quick_xml.rs
+++ b/src/pipeline/renderer/steps/serde/quick_xml.rs
@@ -42,7 +42,7 @@ impl CustomData<'_> {
             return;
         };
 
-        ctx.module().usings([include]);
+        ctx.add_usings([include]);
     }
 }
 

--- a/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
+++ b/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
@@ -42,7 +42,7 @@ impl CustomData<'_> {
             return;
         };
 
-        ctx.module().usings([include]);
+        ctx.add_usings([include]);
     }
 }
 

--- a/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
+++ b/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
@@ -44,7 +44,7 @@ impl CustomData<'_> {
             return;
         };
 
-        ctx.module().usings([include]);
+        ctx.add_usings([include]);
     }
 }
 

--- a/src/pipeline/renderer/steps/types.rs
+++ b/src/pipeline/renderer/steps/types.rs
@@ -4,8 +4,8 @@ use quote::quote;
 use crate::config::{RendererFlags, TypedefMode};
 use crate::models::data::{
     ComplexData, ComplexDataAttribute, ComplexDataContent, ComplexDataElement, ComplexDataEnum,
-    ComplexDataStruct, CustomData, DynamicData, EnumerationData, EnumerationTypeVariant, Occurs,
-    ReferenceData, UnionData, UnionTypeVariant,
+    ComplexDataStruct, DynamicData, EnumerationData, EnumerationTypeVariant, Occurs, ReferenceData,
+    UnionData, UnionTypeVariant,
 };
 
 use super::super::{Context, DataTypeVariant, RenderStep};
@@ -18,26 +18,13 @@ pub struct TypesRenderStep;
 impl RenderStep for TypesRenderStep {
     fn render_type(&mut self, ctx: &mut Context<'_, '_>) {
         match &ctx.data.variant {
-            DataTypeVariant::BuildIn(_) => (),
-            DataTypeVariant::Custom(x) => x.render_types(ctx),
+            DataTypeVariant::BuildIn(_) | DataTypeVariant::Custom(_) => (),
             DataTypeVariant::Union(x) => x.render_types(ctx),
             DataTypeVariant::Dynamic(x) => x.render_types(ctx),
             DataTypeVariant::Reference(x) => x.render_types(ctx),
             DataTypeVariant::Enumeration(x) => x.render_types(ctx),
             DataTypeVariant::Complex(x) => x.render_types(ctx),
         }
-    }
-}
-
-/* CustomType */
-
-impl CustomData<'_> {
-    fn render_types(&self, ctx: &mut Context<'_, '_>) {
-        let Some(include) = self.meta.include() else {
-            return;
-        };
-
-        ctx.module().usings([include]);
     }
 }
 

--- a/tests/feature/num_big_int/expected/default.rs
+++ b/tests/feature/num_big_int/expected/default.rs
@@ -1,9 +1,9 @@
-use num::BigInt;
 pub mod tns {
+    use num::BigInt;
     pub type Foo = FooType;
     #[derive(Debug)]
     pub struct FooType {
-        pub a_int: super::BigInt,
-        pub b_int: super::BigInt,
+        pub a_int: BigInt,
+        pub b_int: BigInt,
     }
 }

--- a/tests/feature/num_big_int/expected/quick_xml.rs
+++ b/tests/feature/num_big_int/expected/quick_xml.rs
@@ -1,24 +1,24 @@
-use num::BigInt;
 use xsd_parser::models::schema::Namespace;
 pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
 pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
 pub const NS_TNS: Namespace = Namespace::new_const(b"http://example.com");
 pub mod tns {
+    use num::BigInt;
     use xsd_parser::quick_xml::{Error, WithDeserializer, WithSerializer};
     pub type Foo = FooType;
     #[derive(Debug)]
     pub struct FooType {
-        pub a_int: super::BigInt,
-        pub b_int: super::BigInt,
+        pub a_int: BigInt,
+        pub b_int: BigInt,
     }
     impl FooType {
         #[must_use]
-        pub fn default_a_int() -> super::BigInt {
+        pub fn default_a_int() -> BigInt {
             use core::str::FromStr;
             num::BigInt::from_str("123").unwrap()
         }
         #[must_use]
-        pub fn default_b_int() -> super::BigInt {
+        pub fn default_b_int() -> BigInt {
             use core::str::FromStr;
             num::BigInt::from_str("456").unwrap()
         }
@@ -43,6 +43,7 @@ pub mod tns {
     }
     pub mod quick_xml_deserialize {
         use core::mem::replace;
+        use num::BigInt;
         use xsd_parser::quick_xml::{
             filter_xmlns_attributes, BytesStart, DeserializeReader, Deserializer,
             DeserializerArtifact, DeserializerEvent, DeserializerOutput, DeserializerResult, Error,
@@ -50,8 +51,8 @@ pub mod tns {
         };
         #[derive(Debug)]
         pub struct FooTypeDeserializer {
-            a_int: super::super::BigInt,
-            b_int: super::super::BigInt,
+            a_int: BigInt,
+            b_int: BigInt,
             state: Box<FooTypeDeserializerState>,
         }
         #[derive(Debug)]
@@ -64,8 +65,8 @@ pub mod tns {
             where
                 R: DeserializeReader,
             {
-                let mut a_int: Option<super::super::BigInt> = None;
-                let mut b_int: Option<super::super::BigInt> = None;
+                let mut a_int: Option<BigInt> = None;
+                let mut b_int: Option<BigInt> = None;
                 for attrib in filter_xmlns_attributes(bytes_start) {
                     let attrib = attrib?;
                     if matches!(

--- a/tests/schema/xml_schema/expected/quick_xml.rs
+++ b/tests/schema/xml_schema/expected/quick_xml.rs
@@ -624,13 +624,13 @@ pub struct WildcardType {
     pub id: Option<String>,
     pub namespace: Option<NamespaceListType>,
     pub not_namespace: Option<BasicNamespaceListType>,
-    pub process_contents: WildcardProcessContentsType,
+    pub process_contents: ProcessContentsType,
     pub annotation: Option<AnnotationElementType>,
 }
 impl WildcardType {
     #[must_use]
-    pub fn default_process_contents() -> WildcardProcessContentsType {
-        WildcardProcessContentsType::Strict
+    pub fn default_process_contents() -> ProcessContentsType {
+        ProcessContentsType::Strict
     }
 }
 impl WithDeserializer for WildcardType {
@@ -787,14 +787,14 @@ pub struct AnyAttributeElementType {
     pub id: Option<String>,
     pub namespace: Option<NamespaceListType>,
     pub not_namespace: Option<BasicNamespaceListType>,
-    pub process_contents: WildcardProcessContentsType,
+    pub process_contents: ProcessContentsType,
     pub not_q_name: Option<QnameListAType>,
     pub annotation: Option<AnnotationElementType>,
 }
 impl AnyAttributeElementType {
     #[must_use]
-    pub fn default_process_contents() -> WildcardProcessContentsType {
-        WildcardProcessContentsType::Strict
+    pub fn default_process_contents() -> ProcessContentsType {
+        ProcessContentsType::Strict
     }
 }
 impl WithDeserializer for AnyAttributeElementType {
@@ -835,7 +835,7 @@ pub struct AnyElementType {
     pub id: Option<String>,
     pub namespace: Option<NamespaceListType>,
     pub not_namespace: Option<BasicNamespaceListType>,
-    pub process_contents: WildcardProcessContentsType,
+    pub process_contents: ProcessContentsType,
     pub not_q_name: Option<QnameListType>,
     pub min_occurs: usize,
     pub max_occurs: AllNniType,
@@ -843,8 +843,8 @@ pub struct AnyElementType {
 }
 impl AnyElementType {
     #[must_use]
-    pub fn default_process_contents() -> WildcardProcessContentsType {
-        WildcardProcessContentsType::Strict
+    pub fn default_process_contents() -> ProcessContentsType {
+        ProcessContentsType::Strict
     }
     #[must_use]
     pub fn default_min_occurs() -> usize {
@@ -994,12 +994,12 @@ impl DeserializeBytes for BasicNamespaceListType {
     }
 }
 #[derive(Debug)]
-pub enum WildcardProcessContentsType {
+pub enum ProcessContentsType {
     Skip,
     Lax,
     Strict,
 }
-impl DeserializeBytes for WildcardProcessContentsType {
+impl DeserializeBytes for ProcessContentsType {
     fn deserialize_bytes<R>(reader: &R, bytes: &[u8]) -> Result<Self, Error>
     where
         R: DeserializeReader,
@@ -14053,7 +14053,7 @@ pub mod quick_xml_deserialize {
         id: Option<String>,
         namespace: Option<super::NamespaceListType>,
         not_namespace: Option<super::BasicNamespaceListType>,
-        process_contents: super::WildcardProcessContentsType,
+        process_contents: super::ProcessContentsType,
         annotation: Option<super::AnnotationElementType>,
         state: Box<WildcardTypeDeserializerState>,
     }
@@ -14073,7 +14073,7 @@ pub mod quick_xml_deserialize {
             let mut id: Option<String> = None;
             let mut namespace: Option<super::NamespaceListType> = None;
             let mut not_namespace: Option<super::BasicNamespaceListType> = None;
-            let mut process_contents: Option<super::WildcardProcessContentsType> = None;
+            let mut process_contents: Option<super::ProcessContentsType> = None;
             for attrib in filter_xmlns_attributes(bytes_start) {
                 let attrib = attrib?;
                 if matches!(
@@ -17431,7 +17431,7 @@ pub mod quick_xml_deserialize {
         id: Option<String>,
         namespace: Option<super::NamespaceListType>,
         not_namespace: Option<super::BasicNamespaceListType>,
-        process_contents: super::WildcardProcessContentsType,
+        process_contents: super::ProcessContentsType,
         not_q_name: Option<super::QnameListAType>,
         annotation: Option<super::AnnotationElementType>,
         state: Box<AnyAttributeElementTypeDeserializerState>,
@@ -17452,7 +17452,7 @@ pub mod quick_xml_deserialize {
             let mut id: Option<String> = None;
             let mut namespace: Option<super::NamespaceListType> = None;
             let mut not_namespace: Option<super::BasicNamespaceListType> = None;
-            let mut process_contents: Option<super::WildcardProcessContentsType> = None;
+            let mut process_contents: Option<super::ProcessContentsType> = None;
             let mut not_q_name: Option<super::QnameListAType> = None;
             for attrib in filter_xmlns_attributes(bytes_start) {
                 let attrib = attrib?;
@@ -17929,7 +17929,7 @@ pub mod quick_xml_deserialize {
         id: Option<String>,
         namespace: Option<super::NamespaceListType>,
         not_namespace: Option<super::BasicNamespaceListType>,
-        process_contents: super::WildcardProcessContentsType,
+        process_contents: super::ProcessContentsType,
         not_q_name: Option<super::QnameListType>,
         min_occurs: usize,
         max_occurs: super::AllNniType,
@@ -17952,7 +17952,7 @@ pub mod quick_xml_deserialize {
             let mut id: Option<String> = None;
             let mut namespace: Option<super::NamespaceListType> = None;
             let mut not_namespace: Option<super::BasicNamespaceListType> = None;
-            let mut process_contents: Option<super::WildcardProcessContentsType> = None;
+            let mut process_contents: Option<super::ProcessContentsType> = None;
             let mut not_q_name: Option<super::QnameListType> = None;
             let mut min_occurs: Option<usize> = None;
             let mut max_occurs: Option<super::AllNniType> = None;


### PR DESCRIPTION
The `update_schema` example did not produce valid code and the generation of the using directives of custom defined types was broken. To solve this we refactored the path information slightly and now store the path data directly in the `TypeRef` instead of recreating it every time.