### PR TITLE
Fix deserialization using `serde` for empty string content

### DIFF
--- a/examples/custom_renderer.rs
+++ b/examples/custom_renderer.rs
@@ -482,7 +482,7 @@ impl CustomRenderStep {
 
     fn render_complex_struct_content(
         &self,
-        content: &ComplexDataContent,
+        content: &ComplexDataContent<'_>,
         ctx: &Context<'_, '_>,
     ) -> Option<TokenStream> {
         let target_type = ctx.resolve_type_for_module(&content.target_type);

--- a/src/pipeline/renderer/steps/quick_xml/deserialize.rs
+++ b/src/pipeline/renderer/steps/quick_xml/deserialize.rs
@@ -1504,7 +1504,7 @@ impl ComplexDataStruct<'_> {
     }
 
     fn render_deserializer_fn_init(&self, ctx: &mut Context<'_, '_>) -> TokenStream {
-        if matches!(&self.mode, StructMode::Content { content } if content.is_simple) {
+        if matches!(&self.mode, StructMode::Content { content } if content.is_simple()) {
             self.render_deserializer_fn_init_simple(ctx)
         } else if self.represents_element() {
             self.render_deserializer_fn_init_for_element(ctx)
@@ -1586,7 +1586,7 @@ impl ComplexDataStruct<'_> {
                 self.render_deserializer_fn_next_empty(ctx, *allow_any)
             }
             StructMode::Content { content } => {
-                if content.is_simple {
+                if content.is_simple() {
                     self.render_deserializer_fn_next_content_simple(ctx)
                 } else {
                     self.render_deserializer_fn_next_content_complex(ctx, content)
@@ -1658,7 +1658,7 @@ impl ComplexDataStruct<'_> {
     fn render_deserializer_fn_next_content_complex(
         &self,
         ctx: &Context<'_, '_>,
-        content: &ComplexDataContent,
+        content: &ComplexDataContent<'_>,
     ) -> TokenStream {
         let target_type = ctx.resolve_type_for_deserialize_module(&content.target_type);
         let (event_at, return_end_event) = self.return_end_event(ctx);
@@ -1944,13 +1944,13 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn need_next_state(&self) -> bool {
-        !self.is_simple
+        !self.is_simple()
     }
 
     fn need_done_state(&self, represents_element: bool) -> bool {
-        !self.is_simple && !represents_element && self.max_occurs.is_bounded()
+        !self.is_simple() && !represents_element && self.max_occurs.is_bounded()
     }
 
     fn deserializer_field_decl(&self, ctx: &Context<'_, '_>) -> TokenStream {
@@ -2045,7 +2045,7 @@ impl ComplexDataContent {
         represents_element: bool,
         deserializer_state_ident: &Ident2,
     ) -> TokenStream {
-        if self.is_simple {
+        if self.is_simple() {
             self.deserializer_struct_field_fn_handle_simple(
                 ctx,
                 type_ident,

--- a/src/pipeline/renderer/steps/quick_xml/serialize.rs
+++ b/src/pipeline/renderer/steps/quick_xml/serialize.rs
@@ -786,7 +786,7 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn render_serializer_state_variant(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
         let serializer = self
             .occurs

--- a/src/pipeline/renderer/steps/serde/mod.rs
+++ b/src/pipeline/renderer/steps/serde/mod.rs
@@ -9,12 +9,29 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::models::code::IdentPath;
+use crate::models::data::ComplexDataContent;
+use crate::models::meta::MetaTypes;
+use crate::models::Ident;
 
 pub use self::quick_xml::SerdeQuickXmlTypesRenderStep;
 pub use self::serde_xml_rs_v7::SerdeXmlRsV7TypesRenderStep;
 pub use self::serde_xml_rs_v8::SerdeXmlRsV8TypesRenderStep;
 
 use super::super::Context;
+
+impl ComplexDataContent<'_> {
+    fn is_empty_string_content(&self, types: &MetaTypes) -> bool {
+        if let Some(ident) = &self.simple_type {
+            if let Some(ident) = types.get_resolved_ident(ident) {
+                if *ident == Ident::STRING {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
 
 fn get_derive<I>(ctx: &Context<'_, '_>, extra: I) -> TokenStream
 where

--- a/src/pipeline/renderer/steps/serde/quick_xml.rs
+++ b/src/pipeline/renderer/steps/serde/quick_xml.rs
@@ -341,13 +341,14 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn render_field_serde_quick_xml(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.make_type(&target_type, false)?;
 
-        let default = (self.min_occurs == 0).then(|| quote!(default,));
-        let name = if self.is_simple { "$text" } else { "$value" };
+        let default =
+            (self.is_empty_string_content(ctx) || self.min_occurs == 0).then(|| quote!(default,));
+        let name = if self.is_simple() { "$text" } else { "$value" };
 
         Some(quote! {
             #[serde(#default rename = #name)]

--- a/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
+++ b/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
@@ -341,12 +341,13 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn render_field_serde_xml_rs_v7(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.make_type(&target_type, false)?;
 
-        let default = (self.min_occurs == 0).then(|| quote!(default,));
+        let default =
+            (self.is_empty_string_content(ctx) || self.min_occurs == 0).then(|| quote!(default,));
 
         Some(quote! {
             #[serde(#default rename = "$value")]

--- a/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
+++ b/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
@@ -399,12 +399,13 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn render_field_serde_xml_rs_v8(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.array_to_vec().make_type(&target_type, false)?;
 
-        let default = (self.min_occurs == 0).then(|| quote!(default,));
+        let default =
+            (self.is_empty_string_content(ctx) || self.min_occurs == 0).then(|| quote!(default,));
 
         match ctx
             .get_resolved_complex_content()

--- a/src/pipeline/renderer/steps/types.rs
+++ b/src/pipeline/renderer/steps/types.rs
@@ -301,7 +301,7 @@ impl ComplexDataStruct<'_> {
     }
 }
 
-impl ComplexDataContent {
+impl ComplexDataContent<'_> {
     fn render_field(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.make_type(&target_type, false)?;

--- a/tests/feature/empty_string/example/complex.xml
+++ b/tests/feature/empty_string/example/complex.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ComplexContent lang="">
+    <Content></Content>
+</ComplexContent>

--- a/tests/feature/empty_string/example/simple.xml
+++ b/tests/feature/empty_string/example/simple.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SimpleContent lang=""></SimpleContent>

--- a/tests/feature/empty_string/expected/serde_quick_xml.rs
+++ b/tests/feature/empty_string/expected/serde_quick_xml.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+pub type ComplexContent = ComplexContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComplexContentType {
+    #[serde(rename = "@lang")]
+    pub lang: String,
+    #[serde(rename = "Content")]
+    pub content: String,
+}
+pub type SimpleContent = SimpleContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimpleContentType {
+    #[serde(rename = "@lang")]
+    pub lang: String,
+    #[serde(default, rename = "$text")]
+    pub content: String,
+}
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntitiesType(pub Vec<String>);
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntityType(pub Vec<String>);
+pub type IdType = String;
+pub type IdrefType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct IdrefsType(pub Vec<String>);
+pub type NcNameType = String;
+pub type NmtokenType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct NmtokensType(pub Vec<String>);
+pub type NotationType = String;
+pub type NameType = String;
+pub type QNameType = String;
+pub type AnySimpleType = String;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AnyType;
+pub type AnyUriType = String;
+pub type Base64BinaryType = String;
+pub type BooleanType = bool;
+pub type ByteType = i8;
+pub type DateType = String;
+pub type DateTimeType = String;
+pub type DecimalType = f64;
+pub type DoubleType = f64;
+pub type DurationType = String;
+pub type FloatType = f32;
+pub type GDayType = String;
+pub type GMonthType = String;
+pub type GMonthDayType = String;
+pub type GYearType = String;
+pub type GYearMonthType = String;
+pub type HexBinaryType = String;
+pub type IntType = i32;
+pub type IntegerType = i32;
+pub type LanguageType = String;
+pub type LongType = i64;
+pub type NegativeIntegerType = isize;
+pub type NonNegativeIntegerType = usize;
+pub type NonPositiveIntegerType = isize;
+pub type NormalizedStringType = String;
+pub type PositiveIntegerType = usize;
+pub type ShortType = i16;
+pub type StringType = String;
+pub type TimeType = String;
+pub type TokenType = String;
+pub type UnsignedByteType = u8;
+pub type UnsignedIntType = u32;
+pub type UnsignedLongType = u64;
+pub type UnsignedShortType = u16;

--- a/tests/feature/empty_string/expected/serde_xml_rs_v7.rs
+++ b/tests/feature/empty_string/expected/serde_xml_rs_v7.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+pub type ComplexContent = ComplexContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComplexContentType {
+    #[serde(rename = "lang")]
+    pub lang: String,
+    #[serde(rename = "Content")]
+    pub content: String,
+}
+pub type SimpleContent = SimpleContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimpleContentType {
+    #[serde(rename = "lang")]
+    pub lang: String,
+    #[serde(default, rename = "$value")]
+    pub content: String,
+}
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntitiesType(pub Vec<String>);
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntityType(pub Vec<String>);
+pub type IdType = String;
+pub type IdrefType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct IdrefsType(pub Vec<String>);
+pub type NcNameType = String;
+pub type NmtokenType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct NmtokensType(pub Vec<String>);
+pub type NotationType = String;
+pub type NameType = String;
+pub type QNameType = String;
+pub type AnySimpleType = String;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AnyType;
+pub type AnyUriType = String;
+pub type Base64BinaryType = String;
+pub type BooleanType = bool;
+pub type ByteType = i8;
+pub type DateType = String;
+pub type DateTimeType = String;
+pub type DecimalType = f64;
+pub type DoubleType = f64;
+pub type DurationType = String;
+pub type FloatType = f32;
+pub type GDayType = String;
+pub type GMonthType = String;
+pub type GMonthDayType = String;
+pub type GYearType = String;
+pub type GYearMonthType = String;
+pub type HexBinaryType = String;
+pub type IntType = i32;
+pub type IntegerType = i32;
+pub type LanguageType = String;
+pub type LongType = i64;
+pub type NegativeIntegerType = isize;
+pub type NonNegativeIntegerType = usize;
+pub type NonPositiveIntegerType = isize;
+pub type NormalizedStringType = String;
+pub type PositiveIntegerType = usize;
+pub type ShortType = i16;
+pub type StringType = String;
+pub type TimeType = String;
+pub type TokenType = String;
+pub type UnsignedByteType = u8;
+pub type UnsignedIntType = u32;
+pub type UnsignedLongType = u64;
+pub type UnsignedShortType = u16;

--- a/tests/feature/empty_string/expected/serde_xml_rs_v8.rs
+++ b/tests/feature/empty_string/expected/serde_xml_rs_v8.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+pub type ComplexContent = ComplexContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ComplexContentType {
+    #[serde(rename = "@lang")]
+    pub lang: String,
+    #[serde(rename = "Content")]
+    pub content: String,
+}
+pub type SimpleContent = SimpleContentType;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimpleContentType {
+    #[serde(rename = "@lang")]
+    pub lang: String,
+    #[serde(default, rename = "#text")]
+    pub content: String,
+}
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntitiesType(pub Vec<String>);
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct EntityType(pub Vec<String>);
+pub type IdType = String;
+pub type IdrefType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct IdrefsType(pub Vec<String>);
+pub type NcNameType = String;
+pub type NmtokenType = String;
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct NmtokensType(pub Vec<String>);
+pub type NotationType = String;
+pub type NameType = String;
+pub type QNameType = String;
+pub type AnySimpleType = String;
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AnyType;
+pub type AnyUriType = String;
+pub type Base64BinaryType = String;
+pub type BooleanType = bool;
+pub type ByteType = i8;
+pub type DateType = String;
+pub type DateTimeType = String;
+pub type DecimalType = f64;
+pub type DoubleType = f64;
+pub type DurationType = String;
+pub type FloatType = f32;
+pub type GDayType = String;
+pub type GMonthType = String;
+pub type GMonthDayType = String;
+pub type GYearType = String;
+pub type GYearMonthType = String;
+pub type HexBinaryType = String;
+pub type IntType = i32;
+pub type IntegerType = i32;
+pub type LanguageType = String;
+pub type LongType = i64;
+pub type NegativeIntegerType = isize;
+pub type NonNegativeIntegerType = usize;
+pub type NonPositiveIntegerType = isize;
+pub type NormalizedStringType = String;
+pub type PositiveIntegerType = usize;
+pub type ShortType = i16;
+pub type StringType = String;
+pub type TimeType = String;
+pub type TokenType = String;
+pub type UnsignedByteType = u8;
+pub type UnsignedIntType = u32;
+pub type UnsignedLongType = u64;
+pub type UnsignedShortType = u16;

--- a/tests/feature/empty_string/mod.rs
+++ b/tests/feature/empty_string/mod.rs
@@ -1,0 +1,111 @@
+use xsd_parser::{config::SerdeXmlRsVersion, Config};
+
+use crate::utils::{generate_test, ConfigEx};
+
+#[test]
+fn generate_serde_xml_rs_v7() {
+    generate_test(
+        "tests/feature/empty_string/schema.xsd",
+        "tests/feature/empty_string/expected/serde_xml_rs_v7.rs",
+        Config::test_default().with_serde_xml_rs(SerdeXmlRsVersion::Version07AndBelow),
+    );
+}
+
+#[test]
+fn generate_serde_xml_rs_v8() {
+    generate_test(
+        "tests/feature/empty_string/schema.xsd",
+        "tests/feature/empty_string/expected/serde_xml_rs_v8.rs",
+        Config::test_default().with_serde_xml_rs(SerdeXmlRsVersion::Version08AndAbove),
+    );
+}
+
+#[test]
+fn generate_serde_quick_xml() {
+    generate_test(
+        "tests/feature/empty_string/schema.xsd",
+        "tests/feature/empty_string/expected/serde_quick_xml.rs",
+        Config::test_default().with_serde_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs_v7() {
+    use serde_xml_rs_v7::{ComplexContent, SimpleContent};
+
+    let obj = crate::utils::serde_xml_rs_v7_read_test::<SimpleContent, _>(
+        "tests/feature/empty_string/example/simple.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+
+    let obj = crate::utils::serde_xml_rs_v7_read_test::<ComplexContent, _>(
+        "tests/feature/empty_string/example/complex.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs_v8() {
+    use serde_xml_rs_v8::{ComplexContent, SimpleContent};
+
+    let obj = crate::utils::serde_xml_rs_read_test::<SimpleContent, _>(
+        "tests/feature/empty_string/example/simple.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+
+    let obj = crate::utils::serde_xml_rs_read_test::<ComplexContent, _>(
+        "tests/feature/empty_string/example/complex.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_quick_xml() {
+    use serde_quick_xml::{ComplexContent, SimpleContent};
+
+    let obj = crate::utils::serde_quick_xml_read_test::<SimpleContent, _>(
+        "tests/feature/empty_string/example/simple.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+
+    let obj = crate::utils::serde_quick_xml_read_test::<ComplexContent, _>(
+        "tests/feature/empty_string/example/complex.xml",
+    );
+
+    assert_eq!(obj.lang, "");
+    assert_eq!(obj.content, "");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs_v7 {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs_v7.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs_v8 {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs_v8.rs");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_quick_xml.rs");
+}

--- a/tests/feature/empty_string/schema.xsd
+++ b/tests/feature/empty_string/schema.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="SimpleContent">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="lang" type="xs:string" use="required"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ComplexContent">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="Content" type="xs:string" />
+            </xs:sequence>
+            <xs:attribute name="lang" type="xs:string" use="required" />
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/feature/mod.rs
+++ b/tests/feature/mod.rs
@@ -12,6 +12,7 @@ mod complex_type_with_repeated_content;
 mod documentation;
 mod dynamic_types;
 mod element_without_type;
+mod empty_string;
 mod enumeration;
 mod enumeration_with_annotation;
 mod extension_base;

--- a/tests/schema/ideal_merchant_acquirer/expected/serde_quick_xml.rs
+++ b/tests/schema/ideal_merchant_acquirer/expected/serde_quick_xml.rs
@@ -46,7 +46,7 @@ pub struct SignedInfoType {
 pub struct SignatureValueType {
     #[serde(default, rename = "@Id")]
     pub id: Option<String>,
-    #[serde(rename = "$text")]
+    #[serde(default, rename = "$text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/schema/ideal_merchant_acquirer/expected/serde_xml_rs_v7.rs
+++ b/tests/schema/ideal_merchant_acquirer/expected/serde_xml_rs_v7.rs
@@ -46,7 +46,7 @@ pub struct SignedInfoType {
 pub struct SignatureValueType {
     #[serde(default, rename = "Id")]
     pub id: Option<String>,
-    #[serde(rename = "$value")]
+    #[serde(default, rename = "$value")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/schema/xcb/expected/serde_quick_xml.rs
+++ b/tests/schema/xcb/expected/serde_quick_xml.rs
@@ -440,7 +440,7 @@ pub enum UnopTypeContent {
 pub struct EnumrefType {
     #[serde(rename = "@ref")]
     pub ref_: String,
-    #[serde(rename = "$text")]
+    #[serde(default, rename = "$text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]
@@ -512,14 +512,14 @@ pub enum CaseexprTypeContent {
 pub struct FieldType {
     #[serde(default, rename = "@name")]
     pub name: Option<String>,
-    #[serde(rename = "$text")]
+    #[serde(default, rename = "$text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorType {
     #[serde(default, rename = "@type")]
     pub type_: Option<String>,
-    #[serde(rename = "$text")]
+    #[serde(default, rename = "$text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/schema/xcb/expected/serde_xml_rs.rs
+++ b/tests/schema/xcb/expected/serde_xml_rs.rs
@@ -440,7 +440,7 @@ pub enum UnopTypeContent {
 pub struct EnumrefType {
     #[serde(rename = "@ref")]
     pub ref_: String,
-    #[serde(rename = "#text")]
+    #[serde(default, rename = "#text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]
@@ -512,14 +512,14 @@ pub enum CaseexprTypeContent {
 pub struct FieldType {
     #[serde(default, rename = "@name")]
     pub name: Option<String>,
-    #[serde(rename = "#text")]
+    #[serde(default, rename = "#text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorType {
     #[serde(default, rename = "@type")]
     pub type_: Option<String>,
-    #[serde(rename = "#text")]
+    #[serde(default, rename = "#text")]
     pub content: String,
 }
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Elements with simple content and `String` as content type raised an error during deserialization if the content of the element was empty. As fix we added the `#[serde(default)]` attribute for this types.

Related to #107 