### PR TITLE
Added example for custom variants

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,11 @@ It demonstrates a more advanced use of the generator to create types from the sc
 Short example that shows how to assign custom defined names to the generated types.
 
 
+# custom_variants
+
+Similar to ```custom_names```, this example shows how to assign custom names for enumeration variants.
+
+
 # custom_render_step
 
 Example that explains how to implement user defined render steps. This is useful if you want to generate additional structures from the already parsed and interpreted schema.

--- a/examples/custom_variants.rs
+++ b/examples/custom_variants.rs
@@ -1,0 +1,62 @@
+//! Short example that shows how to assign custom defined names to
+//! enumeration variants. See custom_names.rs for more details.
+
+#![allow(missing_docs)]
+
+use anyhow::Error;
+use quote::ToTokens;
+use xsd_parser::{
+    config::{
+        Config, GeneratorFlags, InterpreterFlags, OptimizerFlags, ParserFlags, Resolver, Schema,
+    },
+    exec_generator, exec_interpreter, exec_optimizer, exec_parser, exec_render,
+    models::meta::{MetaTypeVariant, MetaTypes},
+};
+
+fn main() -> Result<(), Error> {
+    // Create the configuration that is used by the generation process. For more
+    // details about the different values refer to the `simple` example or directly
+    // to the documentation of the values.
+    let mut config = Config::default();
+    config.parser.resolver = vec![Resolver::File];
+    config.parser.flags = ParserFlags::all();
+    config.parser.schemas = vec![Schema::File("examples/restriction.xsd".into())];
+    config.interpreter.flags = InterpreterFlags::all();
+    config.optimizer.flags = OptimizerFlags::all() - OptimizerFlags::REMOVE_DUPLICATES;
+    config.generator.flags = GeneratorFlags::all();
+
+    // Execute the different steps of the code generation process. The `replace_variant_names`
+    // function defines a custom step inside the process to set custom names for specified variants.
+    let schemas = exec_parser(config.parser)?;
+    let meta_types = exec_interpreter(config.interpreter, &schemas)?;
+    let meta_types = replace_variant_names(meta_types)?;
+    let meta_types = exec_optimizer(config.optimizer, meta_types)?;
+    let data_types = exec_generator(config.generator, &schemas, &meta_types)?;
+    let module = exec_render(config.renderer, &data_types)?;
+    let code = module.to_token_stream().to_string();
+
+    // Print the generated code to stdout.
+    println!("{code}");
+
+    Ok(())
+}
+
+/// Define custom names for specific variants. Plus and minus characters are invalid identifiers in Rust.
+fn replace_variant_names(mut types: MetaTypes) -> Result<MetaTypes, Error> {
+    for (_ident, ty) in types.items.iter_mut() {
+        if let MetaTypeVariant::Enumeration(enum_meta) = &mut ty.variant {
+            for variant in enum_meta.variants.iter_mut() {
+                match variant.ident.name.as_str() {
+                    "+" => {
+                        variant.display_name = Some("Plus".to_string());
+                    }
+                    "-" => {
+                        variant.display_name = Some("Minus".to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    Ok(types)
+}

--- a/examples/restriction.xsd
+++ b/examples/restriction.xsd
@@ -1,0 +1,12 @@
+<xs:schema targetNamespace="http://www.example.com/signtype" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xml:lang="en">
+
+  <simpleType name="SignType">
+    <restriction base="xs:string">
+        <enumeration value="-"/>
+        <enumeration value="+"/>
+    </restriction>
+  </simpleType>
+
+</xs:schema>


### PR DESCRIPTION
As requested in #109 this is an example showing how to implement custom variant names, here for the case where the variants have names that don't map to valid Rust identifiers.