### PR TITLE
Implement option to use the full path of build in types

### DIFF
--- a/src/config/generator.rs
+++ b/src/config/generator.rs
@@ -122,7 +122,38 @@ bitflags! {
         /// This will enable code generation for mixed types. This feature needs
         /// to be used with caution, because support for mixed types when using
         /// `serde` is quite limited.
+        ///
+        /// # Examples
+        ///
+        /// Consider the following XML schema:
+        /// ```xml
+        #[doc = include_str!("../../tests/generator/generator_flags/schema.xsd")]
+        /// ```
+        ///
+        /// Enable the `BUILD_IN_ABSOLUTE_PATHS` feature only will result in the following code:
+        /// ```rust,ignore
+        #[doc = include_str!("../../tests/generator/generator_flags/expected/mixed_type_support.rs")]
+        /// ```
         const MIXED_TYPE_SUPPORT = 1 << 3;
+
+        /// Use absolute paths for build in types.
+        ///
+        /// Using this flag will instruct the generator to use absolute paths
+        /// for build in types (e.g. `usize` or `String`) to avoid naming
+        /// conflicts with generated types.
+        ///
+        /// # Examples
+        ///
+        /// Consider the following XML schema:
+        /// ```xml
+        #[doc = include_str!("../../tests/generator/generator_flags/schema.xsd")]
+        /// ```
+        ///
+        /// Enable the `BUILD_IN_ABSOLUTE_PATHS` feature only will result in the following code:
+        /// ```rust,ignore
+        #[doc = include_str!("../../tests/generator/generator_flags/expected/build_in_absolute_paths.rs")]
+        /// ```
+        const BUILD_IN_ABSOLUTE_PATHS = 1 << 4;
     }
 }
 

--- a/src/models/code/module.rs
+++ b/src/models/code/module.rs
@@ -267,7 +267,7 @@ where
             continue;
         };
 
-        let (ident, path) = ident.into_parts();
+        let (ident, path, _) = ident.into_parts();
 
         let mut module = &mut root;
         for part in path.into_iter().flat_map(|x| x.0) {

--- a/src/models/data/path_data.rs
+++ b/src/models/data/path_data.rs
@@ -54,7 +54,7 @@ impl PathData {
     pub fn into_included(self) -> Self {
         if self.path.module().is_some() {
             let using = format!("{}", &self.path);
-            let (ident, _) = self.path.into_parts();
+            let (ident, _, _) = self.path.into_parts();
 
             Self::from_path(IdentPath::from_ident(ident)).with_using(using)
         } else {

--- a/src/models/meta/type_.rs
+++ b/src/models/meta/type_.rs
@@ -4,6 +4,9 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 
+use quote::format_ident;
+
+use crate::models::code::IdentPath;
 use crate::models::schema::xs::FormChoiceType;
 
 use super::{
@@ -220,6 +223,46 @@ impl BuildInMeta {
             Self::Bool => "bool",
             Self::String => "String",
         }
+    }
+
+    /// Return the absolute path of the build in type as &str.
+    #[must_use]
+    pub fn as_absolute_path(&self) -> &'static str {
+        match self {
+            Self::U8 => "::core::primitive::u8",
+            Self::U16 => "::core::primitive::u16",
+            Self::U32 => "::core::primitive::u32",
+            Self::U64 => "::core::primitive::u64",
+            Self::U128 => "::core::primitive::u128",
+            Self::Usize => "::core::primitive::usize",
+
+            Self::I8 => "::core::primitive::i8",
+            Self::I16 => "::core::primitive::i16",
+            Self::I32 => "::core::primitive::i32",
+            Self::I64 => "::core::primitive::i64",
+            Self::I128 => "::core::primitive::i128",
+            Self::Isize => "::core::primitive::isize",
+
+            Self::F32 => "::core::primitive::f32",
+            Self::F64 => "::core::primitive::f64",
+
+            Self::Bool => "::core::primitive::bool",
+            Self::String => "::std::string::String",
+        }
+    }
+
+    /// Return the relative [`IdentPath`] of the build-in type.
+    #[must_use]
+    pub fn ident_path(&self) -> IdentPath {
+        IdentPath::from_ident(format_ident!("{self}"))
+    }
+
+    /// Return the absolute [`IdentPath`] of the build-in type.
+    #[must_use]
+    pub fn absolute_ident_path(&self) -> IdentPath {
+        use std::str::FromStr;
+
+        IdentPath::from_str(self.as_absolute_path()).unwrap()
     }
 }
 

--- a/src/pipeline/generator/meta.rs
+++ b/src/pipeline/generator/meta.rs
@@ -36,6 +36,7 @@ pub struct MetaData<'types> {
 impl MetaData<'_> {
     /// Whether the passed `flags` intersect with the generator flags set in
     /// the configuration, or not.
+    #[inline]
     #[must_use]
     pub fn check_generator_flags(&self, flags: GeneratorFlags) -> bool {
         self.flags.intersects(flags)

--- a/src/pipeline/generator/mod.rs
+++ b/src/pipeline/generator/mod.rs
@@ -392,7 +392,14 @@ impl<'types> State<'types> {
             let name = make_type_name(&meta.postfixes, ty, ident);
             let path = match &ty.variant {
                 MetaTypeVariant::BuildIn(x) => {
-                    PathData::from_path(IdentPath::from_ident(format_ident!("{x}")))
+                    let path =
+                        if meta.check_generator_flags(GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS) {
+                            x.absolute_ident_path()
+                        } else {
+                            x.ident_path()
+                        };
+
+                    PathData::from_path(path)
                 }
                 MetaTypeVariant::Custom(x) => {
                     let path = IdentPath::from_ident(format_ident!("{}", x.name()));
@@ -404,7 +411,7 @@ impl<'types> State<'types> {
                     }
                 }
                 _ => {
-                    let use_modules = meta.flags.intersects(GeneratorFlags::USE_MODULES);
+                    let use_modules = meta.check_generator_flags(GeneratorFlags::USE_MODULES);
                     let module_ident =
                         format_module(meta.types, use_modules.then_some(ident.ns).flatten())?;
                     let type_ident = format_type_ident(&name, ty.display_name.as_deref());

--- a/tests/generator/generator_flags/expected/build_in_absolute_paths.rs
+++ b/tests/generator/generator_flags/expected/build_in_absolute_paths.rs
@@ -1,0 +1,22 @@
+#[derive(Debug)]
+pub struct MyChoiceType {
+    pub content: MyChoiceTypeContent,
+}
+#[derive(Debug)]
+pub enum MyChoiceTypeContent {
+    Once(::core::primitive::i32),
+    Optional(Option<::core::primitive::i32>),
+    OnceSpecify(::core::primitive::i32),
+    TwiceOrMore(Vec<::core::primitive::i32>),
+}
+#[derive(Debug)]
+pub struct MySequenceType {
+    pub content: MySequenceTypeContent,
+}
+#[derive(Debug)]
+pub struct MySequenceTypeContent {
+    pub once: ::core::primitive::i32,
+    pub optional: Option<::core::primitive::i32>,
+    pub once_specify: ::core::primitive::i32,
+    pub twice_or_more: Vec<::core::primitive::i32>,
+}

--- a/tests/generator/generator_flags/expected/mixed_type_support.rs
+++ b/tests/generator/generator_flags/expected/mixed_type_support.rs
@@ -1,0 +1,25 @@
+use xsd_parser::xml::{Mixed, Text};
+#[derive(Debug)]
+pub struct MyChoiceType {
+    pub text_before: Option<Text>,
+    pub content: MyChoiceTypeContent,
+}
+#[derive(Debug)]
+pub enum MyChoiceTypeContent {
+    Once(Mixed<i32>),
+    Optional(Option<Mixed<i32>>),
+    OnceSpecify(Mixed<i32>),
+    TwiceOrMore(Vec<Mixed<i32>>),
+}
+#[derive(Debug)]
+pub struct MySequenceType {
+    pub text_before: Option<Text>,
+    pub content: MySequenceTypeContent,
+}
+#[derive(Debug)]
+pub struct MySequenceTypeContent {
+    pub once: Mixed<i32>,
+    pub optional: Option<Mixed<i32>>,
+    pub once_specify: Mixed<i32>,
+    pub twice_or_more: Vec<Mixed<i32>>,
+}

--- a/tests/generator/generator_flags/mod.rs
+++ b/tests/generator/generator_flags/mod.rs
@@ -43,3 +43,31 @@ fn flatten_content() {
             ]),
     );
 }
+
+#[test]
+fn mixed_type_support() {
+    generate_test(
+        "tests/generator/generator_flags/schema.xsd",
+        "tests/generator/generator_flags/expected/mixed_type_support.rs",
+        Config::test_default()
+            .set_generator_flags(GeneratorFlags::MIXED_TYPE_SUPPORT)
+            .with_generate([
+                (IdentType::Type, "tns:MyChoice"),
+                (IdentType::Type, "tns:MySequence"),
+            ]),
+    );
+}
+
+#[test]
+fn build_in_absolute_paths() {
+    generate_test(
+        "tests/generator/generator_flags/schema.xsd",
+        "tests/generator/generator_flags/expected/build_in_absolute_paths.rs",
+        Config::test_default()
+            .set_generator_flags(GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS)
+            .with_generate([
+                (IdentType::Type, "tns:MyChoice"),
+                (IdentType::Type, "tns:MySequence"),
+            ]),
+    );
+}

--- a/tests/generator/generator_flags/schema.xsd
+++ b/tests/generator/generator_flags/schema.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:tns="http://example.com"
     targetNamespace="http://example.com">
-    <xs:complexType name="MyChoice">
+    <xs:complexType name="MyChoice" mixed="true">
         <xs:choice>
             <xs:element name="Once" type="xs:int" />
             <xs:element name="Optional" type="xs:int" minOccurs="0" />
@@ -11,7 +11,7 @@
         </xs:choice>
     </xs:complexType>
 
-    <xs:complexType name="MySequence">
+    <xs:complexType name="MySequence" mixed="true">
         <xs:sequence>
             <xs:element name="Once" type="xs:int" />
             <xs:element name="Optional" type="xs:int" minOccurs="0" />

--- a/tests/schema/bmecat_etim_310/mod.rs
+++ b/tests/schema/bmecat_etim_310/mod.rs
@@ -10,7 +10,7 @@ const NS: Namespace = Namespace::new_const(b"http://www.etim-international.com/b
 
 fn config() -> Config {
     let mut config = Config::test_default()
-        .with_generator_flags(GeneratorFlags::all())
+        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS)
         .with_optimizer_flags(OptimizerFlags::all() - OptimizerFlags::REMOVE_DUPLICATES)
         .with_generate([(
             IdentType::Element,

--- a/tests/schema/bmecat_etim_501/mod.rs
+++ b/tests/schema/bmecat_etim_501/mod.rs
@@ -10,7 +10,7 @@ const NS: Namespace = Namespace::new_const(b"https://www.etim-international.com/
 
 fn config() -> Config {
     let mut config = Config::test_default()
-        .with_generator_flags(GeneratorFlags::all())
+        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS)
         .with_optimizer_flags(OptimizerFlags::all() - OptimizerFlags::REMOVE_DUPLICATES)
         .with_generate([(
             IdentType::Element,

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -4,6 +4,7 @@ mod bmecat_etim_310;
 mod bmecat_etim_501;
 mod factur_x;
 mod ideal_merchant_acquirer;
+mod ofd;
 mod onix;
 mod shiporder;
 mod sitemap;

--- a/tests/schema/ofd/expected/quick_xml.rs
+++ b/tests/schema/ofd/expected/quick_xml.rs
@@ -51835,12 +51835,12 @@ pub mod quick_xml_serialize {
                         match self.value {
                             super::CtActionGotoXElementType::Dest(x) => {
                                 *self.state = CtActionGotoXElementTypeSerializerState::Dest(
-                                    WithSerializer::serializer(x, Some("Dest"), false)?,
+                                    WithSerializer::serializer(x, Some("Dest"), self.is_root)?,
                                 )
                             }
                             super::CtActionGotoXElementType::Bookmark(x) => {
                                 *self.state = CtActionGotoXElementTypeSerializerState::Bookmark(
-                                    WithSerializer::serializer(x, Some("Bookmark"), false)?,
+                                    WithSerializer::serializer(x, Some("Bookmark"), self.is_root)?,
                                 )
                             }
                         }

--- a/tests/schema/ofd/mod.rs
+++ b/tests/schema/ofd/mod.rs
@@ -25,9 +25,8 @@ fn config() -> Config {
         ])
         .with_parser_flags(ParserFlags::all())
         .with_interpreter_flags(InterpreterFlags::all())
-        .with_generator_flags(GeneratorFlags::all())
         .with_optimizer_flags(OptimizerFlags::all())
-        .with_generator_flags(GeneratorFlags::all());
+        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS);
 
     config.parser.debug_output = Some("target/parser.log".into());
     config.interpreter.debug_output = Some("target/interpreter.log".into());

--- a/tests/schema/onix/mod.rs
+++ b/tests/schema/onix/mod.rs
@@ -10,7 +10,7 @@ use crate::utils::{generate_test_validate, ConfigEx};
 
 fn config() -> Config {
     let mut config = Config::test_default()
-        .with_generator_flags(GeneratorFlags::all())
+        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS)
         .with_optimizer_flags(
             OptimizerFlags::all()
                 - OptimizerFlags::FLATTEN_COMPLEX_TYPES

--- a/tests/schema/xccdf_1_2/mod.rs
+++ b/tests/schema/xccdf_1_2/mod.rs
@@ -11,7 +11,7 @@ use crate::utils::generate_test_validate;
 fn config() -> Config {
     Config::default()
         .with_optimizer_flags(OptimizerFlags::all())
-        .with_generator_flags(GeneratorFlags::all())
+        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS)
         .with_renderer_flags(RendererFlags::RENDER_DOCS)
         .with_any_support(
             "xsd_parser::xml::AnyElement",

--- a/tests/schema/xml_schema/mod.rs
+++ b/tests/schema/xml_schema/mod.rs
@@ -14,7 +14,11 @@ fn config() -> Config {
                 - OptimizerFlags::SIMPLIFY_MIXED_TYPES
                 - OptimizerFlags::USE_UNRESTRICTED_BASE_TYPE_SIMPLE,
         )
-        .with_generator_flags(GeneratorFlags::all() - GeneratorFlags::USE_MODULES)
+        .with_generator_flags(
+            GeneratorFlags::all()
+                - GeneratorFlags::USE_MODULES
+                - GeneratorFlags::BUILD_IN_ABSOLUTE_PATHS,
+        )
         .with_renderer_flags(RendererFlags::RENDER_DOCS)
         .with_any_support(
             "xsd_parser::xml::AnyElement",


### PR DESCRIPTION
To avoid naming conflicts with build-in types, we implemented an option to use the full path of the build-in type instead just their names.