### PR TITLE
Fix error included schemas without target namespace

### DIFF
--- a/src/pipeline/interpreter/mod.rs
+++ b/src/pipeline/interpreter/mod.rs
@@ -419,7 +419,13 @@ impl<'a> Interpreter<'a> {
 
             self.state.types.schemas.insert(*id, schema);
 
-            SchemaInterpreter::process(&mut self.state, *id, &info.schema, self.schemas)?;
+            SchemaInterpreter::process(
+                &mut self.state,
+                &info.schema,
+                self.schemas,
+                *id,
+                info.namespace_id(),
+            )?;
         }
 
         Ok(self.state.types)

--- a/src/pipeline/interpreter/schema.rs
+++ b/src/pipeline/interpreter/schema.rs
@@ -21,9 +21,10 @@ use super::{state::StackEntry, Error, Node, State, VariantBuilder};
 #[derive(Debug)]
 pub(super) struct SchemaInterpreter<'schema, 'state> {
     pub(super) state: &'state mut State<'schema>,
-    pub(super) schema_id: SchemaId,
     pub(super) schema: &'schema Schema,
     pub(super) schemas: &'schema Schemas,
+    pub(super) schema_id: SchemaId,
+    pub(super) namespace_id: NamespaceId,
 
     pending_element_types: VecDeque<(Ident, &'schema ElementType)>,
 }
@@ -33,9 +34,10 @@ impl<'schema, 'state> SchemaInterpreter<'schema, 'state> {
     #[instrument(level = "trace", skip(state, schema, schemas))]
     pub(super) fn process(
         state: &'state mut State<'schema>,
-        schema_id: SchemaId,
         schema: &'schema Schema,
         schemas: &'schema Schemas,
+        schema_id: SchemaId,
+        namespace_id: NamespaceId,
     ) -> Result<(), Error> {
         let target_namespace = schema
             .target_namespace
@@ -54,9 +56,10 @@ impl<'schema, 'state> SchemaInterpreter<'schema, 'state> {
 
         let mut this = Self {
             state,
-            schema_id,
             schema,
             schemas,
+            schema_id,
+            namespace_id,
             pending_element_types: VecDeque::new(),
         };
 
@@ -303,7 +306,8 @@ impl<'schema> SchemaInterpreter<'schema, '_> {
 
 impl<'schema> SchemaInterpreter<'schema, '_> {
     pub(super) fn find_element(&mut self, ident: Ident) -> Option<&'schema ElementType> {
-        if let Some(Node::Element(x)) = self.state.get_node(self.schemas, self.schema, ident) {
+        if let Some(Node::Element(x)) = self.state.get_node(self.schemas, self.namespace_id, ident)
+        {
             Some(x)
         } else {
             None
@@ -311,7 +315,9 @@ impl<'schema> SchemaInterpreter<'schema, '_> {
     }
 
     pub(super) fn find_simple_type(&mut self, ident: Ident) -> Option<&'schema SimpleBaseType> {
-        if let Some(Node::SimpleType(x)) = self.state.get_node(self.schemas, self.schema, ident) {
+        if let Some(Node::SimpleType(x)) =
+            self.state.get_node(self.schemas, self.namespace_id, ident)
+        {
             Some(x)
         } else {
             None
@@ -319,7 +325,9 @@ impl<'schema> SchemaInterpreter<'schema, '_> {
     }
 
     pub(super) fn find_complex_type(&mut self, ident: Ident) -> Option<&'schema ComplexBaseType> {
-        if let Some(Node::ComplexType(x)) = self.state.get_node(self.schemas, self.schema, ident) {
+        if let Some(Node::ComplexType(x)) =
+            self.state.get_node(self.schemas, self.namespace_id, ident)
+        {
             Some(x)
         } else {
             None
@@ -327,7 +335,7 @@ impl<'schema> SchemaInterpreter<'schema, '_> {
     }
 
     pub(super) fn find_group(&mut self, ident: Ident) -> Option<&'schema GroupType> {
-        if let Some(Node::Group(x)) = self.state.get_node(self.schemas, self.schema, ident) {
+        if let Some(Node::Group(x)) = self.state.get_node(self.schemas, self.namespace_id, ident) {
             Some(x)
         } else {
             None
@@ -338,7 +346,8 @@ impl<'schema> SchemaInterpreter<'schema, '_> {
         &mut self,
         ident: Ident,
     ) -> Option<&'schema AttributeGroupType> {
-        if let Some(Node::AttributeGroup(x)) = self.state.get_node(self.schemas, self.schema, ident)
+        if let Some(Node::AttributeGroup(x)) =
+            self.state.get_node(self.schemas, self.namespace_id, ident)
         {
             Some(x)
         } else {

--- a/tests/feature/include_references/expected/default.rs
+++ b/tests/feature/include_references/expected/default.rs
@@ -1,0 +1,4 @@
+#[derive(Debug)]
+pub struct MyComplexType {
+    pub test: Option<i32>,
+}

--- a/tests/feature/include_references/include.xsd
+++ b/tests/feature/include_references/include.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+	<xs:attributeGroup name="myAttribGroup">
+		<xs:attribute name="test" type="xs:int" />
+	</xs:attributeGroup>
+</xs:schema>

--- a/tests/feature/include_references/mod.rs
+++ b/tests/feature/include_references/mod.rs
@@ -1,0 +1,12 @@
+use xsd_parser::{Config, IdentType};
+
+use crate::utils::{generate_test, ConfigEx};
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/include_references/schema.xsd",
+        "tests/feature/include_references/expected/default.rs",
+        Config::test_default().with_generate([(IdentType::Type, None, "myComplexType")]),
+    );
+}

--- a/tests/feature/include_references/schema.xsd
+++ b/tests/feature/include_references/schema.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+	<xs:include schemaLocation="include.xsd"/>
+	<xs:complexType name="myComplexType">
+		<xs:attributeGroup ref="myAttribGroup"/>
+	</xs:complexType>
+</xs:schema>

--- a/tests/feature/mod.rs
+++ b/tests/feature/mod.rs
@@ -22,6 +22,7 @@ mod extension_simple_content;
 mod extra_derive;
 mod facets;
 mod globally_allowed_attribute;
+mod include_references;
 mod include_target_namespace;
 mod inline_element_names;
 mod list;


### PR DESCRIPTION
When other schemas are included into another schema, while both of them do not specify a target namespace, the elements defined in the included schema could not be resolved inside the interpreter. To solve this we now additionally try to lookup the element in all other schemas of the current "unknown" namespace by using the the namespace id of the current processed schema.

Related to #134 