### PR TITLE
Fix code generation for extended types with mixed content

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tests/feature/mixed_content/example/*.xml text eol=lf
 tests/feature/mixed_content_groups/example/*.xml text eol=lf
+tests/feature/extension_mixed_content/example/*.xml text eol=lf

--- a/src/pipeline/interpreter/variant_builder.rs
+++ b/src/pipeline/interpreter/variant_builder.rs
@@ -1299,6 +1299,10 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
                 ci.content.get_or_insert(base_ident);
             }
             (None, TypeMode::Complex, ContentMode::Simple | ContentMode::Complex) => {
+                if let MetaTypeVariant::ComplexType(ci) = &mut base {
+                    ci.is_mixed = self.state.is_mixed();
+                }
+
                 self.variant = Some(base);
             }
             (_, _, _) => crate::unreachable!("Unset or invalid combination!"),

--- a/tests/feature/extension_mixed_content/example/default.xml
+++ b/tests/feature/extension_mixed_content/example/default.xml
@@ -1,0 +1,7 @@
+<AttributeValue xmlns:tns="http://example.com" BaseAttrib="base attrib content" DataType="data type attrib content" unknown-attrib="unknown content">
+    text before
+    <tns:BaseElement>base element content</tns:BaseElement>
+    text in the middle
+    <unknown-element />
+    text after
+</AttributeValue>

--- a/tests/feature/extension_mixed_content/expected/default.rs
+++ b/tests/feature/extension_mixed_content/expected/default.rs
@@ -1,0 +1,11 @@
+use xsd_parser::xml::{AnyAttributes, AnyElement, Mixed, Text};
+pub type AttributeValue = AttributeValueType;
+#[derive(Debug)]
+pub struct AttributeValueType {
+    pub base_attrib: String,
+    pub data_type: String,
+    pub any_attribute: AnyAttributes,
+    pub text_before: Option<Text>,
+    pub base_element: Mixed<String>,
+    pub any: Vec<Mixed<AnyElement>>,
+}

--- a/tests/feature/extension_mixed_content/expected/quick_xml.rs
+++ b/tests/feature/extension_mixed_content/expected/quick_xml.rs
@@ -1,0 +1,566 @@
+use xsd_parser::{
+    models::schema::Namespace,
+    quick_xml::{Error, WithDeserializer, WithSerializer},
+    xml::{AnyAttributes, AnyElement, Mixed, Text},
+};
+pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
+pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
+pub const NS_TNS: Namespace = Namespace::new_const(b"http://example.com");
+pub type AttributeValue = AttributeValueType;
+#[derive(Debug)]
+pub struct AttributeValueType {
+    pub base_attrib: String,
+    pub data_type: String,
+    pub any_attribute: AnyAttributes,
+    pub text_before: Option<Text>,
+    pub base_element: Mixed<String>,
+    pub any: Vec<Mixed<AnyElement>>,
+}
+impl WithSerializer for AttributeValueType {
+    type Serializer<'x> = quick_xml_serialize::AttributeValueTypeSerializer<'x>;
+    fn serializer<'ser>(
+        &'ser self,
+        name: Option<&'ser str>,
+        is_root: bool,
+    ) -> Result<Self::Serializer<'ser>, Error> {
+        Ok(quick_xml_serialize::AttributeValueTypeSerializer {
+            value: self,
+            state: Box::new(quick_xml_serialize::AttributeValueTypeSerializerState::Init__),
+            name: name.unwrap_or("tns:AttributeValueType"),
+            is_root,
+        })
+    }
+}
+impl WithDeserializer for AttributeValueType {
+    type Deserializer = quick_xml_deserialize::AttributeValueTypeDeserializer;
+}
+pub mod quick_xml_deserialize {
+    use core::mem::replace;
+    use xsd_parser::{
+        quick_xml::{
+            filter_xmlns_attributes, BytesStart, DeserializeReader, Deserializer,
+            DeserializerArtifact, DeserializerEvent, DeserializerOutput, DeserializerResult,
+            ElementHandlerOutput, Error, ErrorKind, Event, RawByteStr, WithDeserializer,
+        },
+        xml::{AnyAttributes, AnyElement, Mixed, Text},
+    };
+    #[derive(Debug)]
+    pub struct AttributeValueTypeDeserializer {
+        base_attrib: String,
+        data_type: String,
+        any_attribute: AnyAttributes,
+        text_before: Option<Text>,
+        base_element: Option<Mixed<String>>,
+        any: Vec<Mixed<AnyElement>>,
+        state__: Box<AttributeValueTypeDeserializerState>,
+    }
+    #[derive(Debug)]
+    enum AttributeValueTypeDeserializerState {
+        Init__,
+        TextBefore(Option<<Text as WithDeserializer>::Deserializer>),
+        BaseElement(Option<<Mixed<String> as WithDeserializer>::Deserializer>),
+        Any(Option<<Mixed<AnyElement> as WithDeserializer>::Deserializer>),
+        Done__,
+        Unknown__,
+    }
+    impl AttributeValueTypeDeserializer {
+        fn from_bytes_start<R>(reader: &R, bytes_start: &BytesStart<'_>) -> Result<Self, Error>
+        where
+            R: DeserializeReader,
+        {
+            let mut base_attrib: Option<String> = None;
+            let mut data_type: Option<String> = None;
+            let mut any_attribute = AnyAttributes::default();
+            for attrib in filter_xmlns_attributes(bytes_start) {
+                let attrib = attrib?;
+                if matches!(
+                    reader.resolve_local_name(attrib.key, &super::NS_TNS),
+                    Some(b"BaseAttrib")
+                ) {
+                    reader.read_attrib(&mut base_attrib, b"BaseAttrib", &attrib.value)?;
+                } else if matches!(
+                    reader.resolve_local_name(attrib.key, &super::NS_TNS),
+                    Some(b"DataType")
+                ) {
+                    reader.read_attrib(&mut data_type, b"DataType", &attrib.value)?;
+                } else {
+                    any_attribute.push(attrib)?;
+                }
+            }
+            Ok(Self {
+                base_attrib: base_attrib.ok_or_else(|| {
+                    reader.map_error(ErrorKind::MissingAttribute("BaseAttrib".into()))
+                })?,
+                data_type: data_type.ok_or_else(|| {
+                    reader.map_error(ErrorKind::MissingAttribute("DataType".into()))
+                })?,
+                any_attribute: any_attribute,
+                text_before: None,
+                base_element: None,
+                any: Vec::new(),
+                state__: Box::new(AttributeValueTypeDeserializerState::Init__),
+            })
+        }
+        fn finish_state<R>(
+            &mut self,
+            reader: &R,
+            state: AttributeValueTypeDeserializerState,
+        ) -> Result<(), Error>
+        where
+            R: DeserializeReader,
+        {
+            use AttributeValueTypeDeserializerState as S;
+            match state {
+                S::TextBefore(Some(deserializer)) => {
+                    self.store_text_before(deserializer.finish(reader)?)?
+                }
+                S::BaseElement(Some(deserializer)) => {
+                    self.store_base_element(deserializer.finish(reader)?)?
+                }
+                S::Any(Some(deserializer)) => self.store_any(deserializer.finish(reader)?)?,
+                _ => (),
+            }
+            Ok(())
+        }
+        fn store_text_before(&mut self, value: Text) -> Result<(), Error> {
+            if self.text_before.is_some() {
+                Err(ErrorKind::DuplicateElement(RawByteStr::from_slice(
+                    b"text_before",
+                )))?;
+            }
+            self.text_before = Some(value);
+            Ok(())
+        }
+        fn store_base_element(&mut self, value: Mixed<String>) -> Result<(), Error> {
+            if self.base_element.is_some() {
+                Err(ErrorKind::DuplicateElement(RawByteStr::from_slice(
+                    b"BaseElement",
+                )))?;
+            }
+            self.base_element = Some(value);
+            Ok(())
+        }
+        fn store_any(&mut self, value: Mixed<AnyElement>) -> Result<(), Error> {
+            self.any.push(value);
+            Ok(())
+        }
+        fn handle_text_before<'de, R>(
+            &mut self,
+            reader: &R,
+            output: DeserializerOutput<'de, Text>,
+            fallback: &mut Option<AttributeValueTypeDeserializerState>,
+        ) -> Result<ElementHandlerOutput<'de>, Error>
+        where
+            R: DeserializeReader,
+        {
+            let DeserializerOutput {
+                artifact,
+                event,
+                allow_any,
+            } = output;
+            if artifact.is_none() {
+                fallback.get_or_insert(AttributeValueTypeDeserializerState::TextBefore(None));
+                *self.state__ = AttributeValueTypeDeserializerState::BaseElement(None);
+                return Ok(ElementHandlerOutput::from_event(event, allow_any));
+            }
+            if let Some(fallback) = fallback.take() {
+                self.finish_state(reader, fallback)?;
+            }
+            Ok(match artifact {
+                DeserializerArtifact::None => unreachable!(),
+                DeserializerArtifact::Data(data) => {
+                    self.store_text_before(data)?;
+                    *self.state__ = AttributeValueTypeDeserializerState::BaseElement(None);
+                    ElementHandlerOutput::from_event(event, allow_any)
+                }
+                DeserializerArtifact::Deserializer(deserializer) => {
+                    let ret = ElementHandlerOutput::from_event(event, allow_any);
+                    match &ret {
+                        ElementHandlerOutput::Continue { .. } => {
+                            fallback.get_or_insert(
+                                AttributeValueTypeDeserializerState::TextBefore(Some(deserializer)),
+                            );
+                            *self.state__ = AttributeValueTypeDeserializerState::BaseElement(None);
+                        }
+                        ElementHandlerOutput::Break { .. } => {
+                            *self.state__ =
+                                AttributeValueTypeDeserializerState::TextBefore(Some(deserializer));
+                        }
+                    }
+                    ret
+                }
+            })
+        }
+        fn handle_base_element<'de, R>(
+            &mut self,
+            reader: &R,
+            output: DeserializerOutput<'de, Mixed<String>>,
+            fallback: &mut Option<AttributeValueTypeDeserializerState>,
+        ) -> Result<ElementHandlerOutput<'de>, Error>
+        where
+            R: DeserializeReader,
+        {
+            let DeserializerOutput {
+                artifact,
+                event,
+                allow_any,
+            } = output;
+            if artifact.is_none() {
+                if self.base_element.is_some() {
+                    fallback.get_or_insert(AttributeValueTypeDeserializerState::BaseElement(None));
+                    *self.state__ = AttributeValueTypeDeserializerState::Any(None);
+                    return Ok(ElementHandlerOutput::from_event(event, allow_any));
+                } else {
+                    *self.state__ = AttributeValueTypeDeserializerState::BaseElement(None);
+                    return Ok(ElementHandlerOutput::break_(event, allow_any));
+                }
+            }
+            if let Some(fallback) = fallback.take() {
+                self.finish_state(reader, fallback)?;
+            }
+            Ok(match artifact {
+                DeserializerArtifact::None => unreachable!(),
+                DeserializerArtifact::Data(data) => {
+                    self.store_base_element(data)?;
+                    *self.state__ = AttributeValueTypeDeserializerState::Any(None);
+                    ElementHandlerOutput::from_event(event, allow_any)
+                }
+                DeserializerArtifact::Deserializer(deserializer) => {
+                    let ret = ElementHandlerOutput::from_event(event, allow_any);
+                    match &ret {
+                        ElementHandlerOutput::Continue { .. } => {
+                            fallback.get_or_insert(
+                                AttributeValueTypeDeserializerState::BaseElement(Some(
+                                    deserializer,
+                                )),
+                            );
+                            *self.state__ = AttributeValueTypeDeserializerState::Any(None);
+                        }
+                        ElementHandlerOutput::Break { .. } => {
+                            *self.state__ = AttributeValueTypeDeserializerState::BaseElement(Some(
+                                deserializer,
+                            ));
+                        }
+                    }
+                    ret
+                }
+            })
+        }
+        fn handle_any<'de, R>(
+            &mut self,
+            reader: &R,
+            output: DeserializerOutput<'de, Mixed<AnyElement>>,
+            fallback: &mut Option<AttributeValueTypeDeserializerState>,
+        ) -> Result<ElementHandlerOutput<'de>, Error>
+        where
+            R: DeserializeReader,
+        {
+            let DeserializerOutput {
+                artifact,
+                event,
+                allow_any,
+            } = output;
+            if artifact.is_none() {
+                fallback.get_or_insert(AttributeValueTypeDeserializerState::Any(None));
+                *self.state__ = AttributeValueTypeDeserializerState::Done__;
+                return Ok(ElementHandlerOutput::from_event(event, allow_any));
+            }
+            if let Some(fallback) = fallback.take() {
+                self.finish_state(reader, fallback)?;
+            }
+            Ok(match artifact {
+                DeserializerArtifact::None => unreachable!(),
+                DeserializerArtifact::Data(data) => {
+                    self.store_any(data)?;
+                    *self.state__ = AttributeValueTypeDeserializerState::Any(None);
+                    ElementHandlerOutput::from_event(event, allow_any)
+                }
+                DeserializerArtifact::Deserializer(deserializer) => {
+                    let ret = ElementHandlerOutput::from_event(event, allow_any);
+                    match &ret {
+                        ElementHandlerOutput::Continue { .. } => {
+                            fallback.get_or_insert(AttributeValueTypeDeserializerState::Any(Some(
+                                deserializer,
+                            )));
+                            *self.state__ = AttributeValueTypeDeserializerState::Any(None);
+                        }
+                        ElementHandlerOutput::Break { .. } => {
+                            *self.state__ =
+                                AttributeValueTypeDeserializerState::Any(Some(deserializer));
+                        }
+                    }
+                    ret
+                }
+            })
+        }
+    }
+    impl<'de> Deserializer<'de, super::AttributeValueType> for AttributeValueTypeDeserializer {
+        fn init<R>(
+            reader: &R,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::AttributeValueType>
+        where
+            R: DeserializeReader,
+        {
+            reader.init_deserializer_from_start_event(event, Self::from_bytes_start)
+        }
+        fn next<R>(
+            mut self,
+            reader: &R,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::AttributeValueType>
+        where
+            R: DeserializeReader,
+        {
+            use AttributeValueTypeDeserializerState as S;
+            let mut event = event;
+            let mut fallback = None;
+            let mut allow_any_element = false;
+            let mut is_any_retry = false;
+            let mut any_fallback = None;
+            let (event, allow_any) = loop {
+                let state = replace(&mut *self.state__, S::Unknown__);
+                event = match (state, event) {
+                    (S::TextBefore(Some(deserializer)), event) => {
+                        let output = deserializer.next(reader, event)?;
+                        match self.handle_text_before(reader, output, &mut fallback)? {
+                            ElementHandlerOutput::Continue { event, allow_any } => {
+                                allow_any_element = allow_any_element || allow_any;
+                                event
+                            }
+                            ElementHandlerOutput::Break { event, allow_any } => {
+                                break (event, allow_any)
+                            }
+                        }
+                    }
+                    (S::BaseElement(Some(deserializer)), event) => {
+                        let output = deserializer.next(reader, event)?;
+                        match self.handle_base_element(reader, output, &mut fallback)? {
+                            ElementHandlerOutput::Continue { event, allow_any } => {
+                                allow_any_element = allow_any_element || allow_any;
+                                event
+                            }
+                            ElementHandlerOutput::Break { event, allow_any } => {
+                                break (event, allow_any)
+                            }
+                        }
+                    }
+                    (S::Any(Some(deserializer)), event) => {
+                        let output = deserializer.next(reader, event)?;
+                        match self.handle_any(reader, output, &mut fallback)? {
+                            ElementHandlerOutput::Continue { event, allow_any } => {
+                                allow_any_element = allow_any_element || allow_any;
+                                event
+                            }
+                            ElementHandlerOutput::Break { event, allow_any } => {
+                                break (event, allow_any)
+                            }
+                        }
+                    }
+                    (_, Event::End(_)) => {
+                        if let Some(fallback) = fallback.take() {
+                            self.finish_state(reader, fallback)?;
+                        }
+                        return Ok(DeserializerOutput {
+                            artifact: DeserializerArtifact::Data(self.finish(reader)?),
+                            event: DeserializerEvent::None,
+                            allow_any: false,
+                        });
+                    }
+                    (S::Init__, event) => {
+                        fallback.get_or_insert(S::Init__);
+                        *self.state__ = AttributeValueTypeDeserializerState::TextBefore(None);
+                        event
+                    }
+                    (S::TextBefore(None), event) => {
+                        let output = <Text as WithDeserializer>::Deserializer::init(reader, event)?;
+                        match self.handle_text_before(reader, output, &mut fallback)? {
+                            ElementHandlerOutput::Continue { event, allow_any } => {
+                                allow_any_element = allow_any_element || allow_any;
+                                event
+                            }
+                            ElementHandlerOutput::Break { event, allow_any } => {
+                                break (event, allow_any)
+                            }
+                        }
+                    }
+                    (S::BaseElement(None), event @ (Event::Start(_) | Event::Empty(_))) => {
+                        let output = reader.init_start_tag_deserializer(
+                            event,
+                            Some(&super::NS_TNS),
+                            b"BaseElement",
+                            false,
+                        )?;
+                        match self.handle_base_element(reader, output, &mut fallback)? {
+                            ElementHandlerOutput::Continue { event, allow_any } => {
+                                allow_any_element = allow_any_element || allow_any;
+                                event
+                            }
+                            ElementHandlerOutput::Break { event, allow_any } => {
+                                break (event, allow_any)
+                            }
+                        }
+                    }
+                    (S::Any(None), event @ (Event::Start(_) | Event::Empty(_))) => {
+                        if is_any_retry {
+                            let output =
+                                <Mixed<AnyElement> as WithDeserializer>::Deserializer::init(
+                                    reader, event,
+                                )?;
+                            match self.handle_any(reader, output, &mut fallback)? {
+                                ElementHandlerOutput::Continue { event, allow_any } => {
+                                    allow_any_element = allow_any_element || allow_any;
+                                    event
+                                }
+                                ElementHandlerOutput::Break { event, allow_any } => {
+                                    break (event, allow_any)
+                                }
+                            }
+                        } else {
+                            any_fallback.get_or_insert(S::Any(None));
+                            *self.state__ = S::Done__;
+                            event
+                        }
+                    }
+                    (S::Done__, event) => {
+                        if let Some(state) = any_fallback.take() {
+                            is_any_retry = true;
+                            *self.state__ = state;
+                            event
+                        } else {
+                            fallback.get_or_insert(S::Done__);
+                            break (DeserializerEvent::Continue(event), allow_any_element);
+                        }
+                    }
+                    (S::Unknown__, _) => unreachable!(),
+                    (state, event) => {
+                        *self.state__ = state;
+                        break (DeserializerEvent::Break(event), false);
+                    }
+                }
+            };
+            if let Some(fallback) = fallback {
+                *self.state__ = fallback;
+            }
+            Ok(DeserializerOutput {
+                artifact: DeserializerArtifact::Deserializer(self),
+                event,
+                allow_any,
+            })
+        }
+        fn finish<R>(mut self, reader: &R) -> Result<super::AttributeValueType, Error>
+        where
+            R: DeserializeReader,
+        {
+            let state = replace(
+                &mut *self.state__,
+                AttributeValueTypeDeserializerState::Unknown__,
+            );
+            self.finish_state(reader, state)?;
+            Ok(super::AttributeValueType {
+                base_attrib: self.base_attrib,
+                data_type: self.data_type,
+                any_attribute: self.any_attribute,
+                text_before: self.text_before,
+                base_element: self
+                    .base_element
+                    .ok_or_else(|| ErrorKind::MissingElement("BaseElement".into()))?,
+                any: self.any,
+            })
+        }
+    }
+}
+pub mod quick_xml_serialize {
+    use core::iter::Iterator;
+    use xsd_parser::{
+        quick_xml::{
+            write_attrib, BytesEnd, BytesStart, Error, Event, IterSerializer, WithSerializer,
+        },
+        xml::{AnyElement, Mixed, Text},
+    };
+    #[derive(Debug)]
+    pub struct AttributeValueTypeSerializer<'ser> {
+        pub(super) value: &'ser super::AttributeValueType,
+        pub(super) state: Box<AttributeValueTypeSerializerState<'ser>>,
+        pub(super) name: &'ser str,
+        pub(super) is_root: bool,
+    }
+    #[derive(Debug)]
+    pub(super) enum AttributeValueTypeSerializerState<'ser> {
+        Init__,
+        TextBefore(IterSerializer<'ser, Option<&'ser Text>, Text>),
+        BaseElement(<Mixed<String> as WithSerializer>::Serializer<'ser>),
+        Any(IterSerializer<'ser, &'ser [Mixed<AnyElement>], Mixed<AnyElement>>),
+        End__,
+        Done__,
+        Phantom__(&'ser ()),
+    }
+    impl<'ser> AttributeValueTypeSerializer<'ser> {
+        fn next_event(&mut self) -> Result<Option<Event<'ser>>, Error> {
+            loop {
+                match &mut *self.state {
+                    AttributeValueTypeSerializerState::Init__ => {
+                        *self.state = AttributeValueTypeSerializerState::TextBefore(
+                            IterSerializer::new(self.value.text_before.as_ref(), Some(""), false),
+                        );
+                        let mut bytes = BytesStart::new(self.name);
+                        if self.is_root {
+                            bytes.push_attribute((&b"xmlns:tns"[..], &super::NS_TNS[..]));
+                        }
+                        write_attrib(&mut bytes, "BaseAttrib", &self.value.base_attrib)?;
+                        write_attrib(&mut bytes, "DataType", &self.value.data_type)?;
+                        bytes.extend_attributes(self.value.any_attribute.attributes());
+                        return Ok(Some(Event::Start(bytes)));
+                    }
+                    AttributeValueTypeSerializerState::TextBefore(x) => {
+                        match x.next().transpose()? {
+                            Some(event) => return Ok(Some(event)),
+                            None => {
+                                *self.state = AttributeValueTypeSerializerState::BaseElement(
+                                    WithSerializer::serializer(
+                                        &self.value.base_element,
+                                        Some("tns:BaseElement"),
+                                        false,
+                                    )?,
+                                )
+                            }
+                        }
+                    }
+                    AttributeValueTypeSerializerState::BaseElement(x) => {
+                        match x.next().transpose()? {
+                            Some(event) => return Ok(Some(event)),
+                            None => {
+                                *self.state = AttributeValueTypeSerializerState::Any(
+                                    IterSerializer::new(&self.value.any[..], Some("any4"), false),
+                                )
+                            }
+                        }
+                    }
+                    AttributeValueTypeSerializerState::Any(x) => match x.next().transpose()? {
+                        Some(event) => return Ok(Some(event)),
+                        None => *self.state = AttributeValueTypeSerializerState::End__,
+                    },
+                    AttributeValueTypeSerializerState::End__ => {
+                        *self.state = AttributeValueTypeSerializerState::Done__;
+                        return Ok(Some(Event::End(BytesEnd::new(self.name))));
+                    }
+                    AttributeValueTypeSerializerState::Done__ => return Ok(None),
+                    AttributeValueTypeSerializerState::Phantom__(_) => unreachable!(),
+                }
+            }
+        }
+    }
+    impl<'ser> Iterator for AttributeValueTypeSerializer<'ser> {
+        type Item = Result<Event<'ser>, Error>;
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.next_event() {
+                Ok(Some(event)) => Some(Ok(event)),
+                Ok(None) => None,
+                Err(error) => {
+                    *self.state = AttributeValueTypeSerializerState::Done__;
+                    Some(Err(error))
+                }
+            }
+        }
+    }
+}

--- a/tests/feature/extension_mixed_content/mod.rs
+++ b/tests/feature/extension_mixed_content/mod.rs
@@ -1,0 +1,133 @@
+use xsd_parser::{config::GeneratorFlags, Config, IdentType};
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default()
+        .with_any_support(
+            "xsd_parser::xml::AnyElement",
+            "xsd_parser::xml::AnyAttributes",
+        )
+        .with_generator_flags(GeneratorFlags::MIXED_TYPE_SUPPORT)
+        .with_generate([(IdentType::Element, "tns:AttributeValue")])
+}
+
+#[cfg(not(feature = "update-expectations"))]
+macro_rules! check_obj {
+    ($module:ident, $obj:expr) => {{
+        use xsd_parser::xml::Text;
+
+        let obj = dbg!($obj);
+
+        assert_eq!(obj.base_attrib, "base attrib content");
+        assert_eq!(obj.data_type, "data type attrib content");
+        assert!(matches!(
+            obj.text_before.as_ref().map(Text::as_str),
+            Some("\n    text before\n    ")
+        ));
+        assert_eq!(obj.base_element.value, "base element content");
+        assert!(matches!(
+            obj.base_element.text_after.as_ref().map(Text::as_str),
+            Some("\n    text in the middle\n    ")
+        ));
+
+        let mut attribs = obj.any_attribute.attributes();
+        assert!(matches!(attribs.next(), Some(_)));
+        assert!(attribs.next().is_none());
+
+        let mut elements = obj.any.into_iter();
+        let element = elements.next().unwrap();
+        assert_eq!(&element.name[..], &b"unknown-element"[..]);
+        assert!(matches!(
+            element.text_after.as_ref().map(Text::as_str),
+            Some("\n    text after\n")
+        ));
+        assert!(elements.next().is_none());
+    }};
+}
+
+#[cfg(not(feature = "update-expectations"))]
+macro_rules! test_obj {
+    ($module:ident) => {{
+        use xsd_parser::xml::{AnyAttributes, AnyElement, Mixed};
+        use $module::AttributeValue;
+
+        let mut any_attribute = AnyAttributes::default();
+        any_attribute.insert(b"unknown-attrib", b"unknown content");
+
+        AttributeValue {
+            base_attrib: "base attrib content".into(),
+            data_type: "data type attrib content".into(),
+            any_attribute,
+            text_before: Some("text before".into()),
+            base_element: Mixed {
+                value: "base element content".into(),
+                text_after: Some("text in the middle".into()),
+            },
+            any: vec![Mixed {
+                value: AnyElement::new().name(b"unknown-element"),
+                text_after: Some("text after".into()),
+            }],
+        }
+    }};
+}
+
+/* default */
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/extension_mixed_content/schema.xsd",
+        "tests/feature/extension_mixed_content/expected/default.rs",
+        config(),
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+/* quick_xml */
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/feature/extension_mixed_content/schema.xsd",
+        "tests/feature/extension_mixed_content/expected/quick_xml.rs",
+        config().with_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::AttributeValue;
+
+    let obj = crate::utils::quick_xml_read_test::<AttributeValue, _>(
+        "tests/feature/extension_mixed_content/example/default.xml",
+    );
+
+    check_obj!(quick_xml, obj);
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn write_quick_xml() {
+    let obj = test_obj!(quick_xml);
+
+    crate::utils::quick_xml_write_test(
+        &obj,
+        "AttributeValue",
+        "tests/feature/extension_mixed_content/example/default.xml",
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}

--- a/tests/feature/extension_mixed_content/schema.xsd
+++ b/tests/feature/extension_mixed_content/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://example.com"
+    targetNamespace="http://example.com"
+    elementFormDefault="qualified">
+
+    <xs:element name="AttributeValue" type="tns:AttributeValueType" />
+
+    <xs:complexType name="AttributeValueType" mixed="true">
+        <xs:complexContent mixed="true">
+            <xs:extension base="tns:ExpressionType">
+                <xs:sequence>
+                    <xs:any namespace="##any" processContents="lax" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xs:sequence>
+                <xs:attribute name="DataType" type="xs:anyURI" use="required" />
+                <xs:anyAttribute namespace="##any" processContents="lax" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ExpressionType">
+        <xs:sequence>
+            <xs:element name="BaseElement" type="xs:string" />
+        </xs:sequence>
+        <xs:attribute name="BaseAttrib" type="xs:string" use="required" />
+    </xs:complexType>
+</xs:schema>

--- a/tests/feature/mod.rs
+++ b/tests/feature/mod.rs
@@ -19,6 +19,7 @@ mod enumeration_with_annotation;
 mod extension_base;
 mod extension_base_multilayer;
 mod extension_base_two_files;
+mod extension_mixed_content;
 mod extension_simple_content;
 mod extra_derive;
 mod facets;


### PR DESCRIPTION
If a type was extended, the mixed attribute was not evaluated correctly. Instead of using the attribute from the current type definition, the value from the base type was used.

Related to #148 