### PR TITLE
IdentPath for derive to make it easier to use 3rd party derive macros

### DIFF
--- a/examples/custom_render_step.rs
+++ b/examples/custom_render_step.rs
@@ -35,10 +35,14 @@ use tracing_subscriber::{fmt, EnvFilter};
 use xsd_parser::{
     config::{GeneratorFlags, OptimizerFlags, ParserFlags, Schema, TypedefMode},
     generate,
-    models::data::{
-        ComplexData, ComplexDataAttribute, ComplexDataContent, ComplexDataElement, ComplexDataEnum,
-        ComplexDataStruct, CustomData, DataTypeVariant, DynamicData, EnumerationData,
-        EnumerationTypeVariant, Occurs, ReferenceData, SimpleData, UnionData, UnionTypeVariant,
+    models::{
+        code::IdentPath,
+        data::{
+            ComplexData, ComplexDataAttribute, ComplexDataContent, ComplexDataElement,
+            ComplexDataEnum, ComplexDataStruct, CustomData, DataTypeVariant, DynamicData,
+            EnumerationData, EnumerationTypeVariant, Occurs, ReferenceData, SimpleData, UnionData,
+            UnionTypeVariant,
+        },
     },
     pipeline::renderer::{Context, RenderStep, RenderStepType},
     Config,
@@ -495,7 +499,9 @@ where
     I: IntoIterator,
     I::Item: Display,
 {
-    let extra = extra.into_iter().map(|x| format_ident!("{x}"));
+    let extra = extra
+        .into_iter()
+        .map(|x| IdentPath::from_ident(format_ident!("{x}")));
     let types = ctx.derive.iter().cloned().chain(extra).collect::<Vec<_>>();
 
     if types.is_empty() {

--- a/src/pipeline/renderer/meta.rs
+++ b/src/pipeline/renderer/meta.rs
@@ -18,7 +18,7 @@ pub struct MetaData<'types> {
     pub flags: RendererFlags,
 
     /// Traits the renderer should derive all types from.
-    pub derive: Vec<Ident2>,
+    pub derive: Vec<IdentPath>,
 
     /// List of traits that should be implemented by dynamic types.
     pub dyn_type_traits: Vec<IdentPath>,

--- a/src/pipeline/renderer/mod.rs
+++ b/src/pipeline/renderer/mod.rs
@@ -72,7 +72,7 @@ impl<'types> Renderer<'types> {
         let meta = MetaData {
             types,
             flags: RendererFlags::empty(),
-            derive: vec![format_ident!("Debug")],
+            derive: vec![IdentPath::from_ident(format_ident!("Debug"))],
             dyn_type_traits: Vec::new(),
             xsd_parser_crate: format_ident!("xsd_parser"),
         };
@@ -136,7 +136,10 @@ impl<'types> Renderer<'types> {
         I: IntoIterator,
         I::Item: Display,
     {
-        self.meta.derive = value.into_iter().map(|x| format_ident!("{x}")).collect();
+        self.meta.derive = value
+            .into_iter()
+            .map(|x| IdentPath::from_str(&x.to_string()).expect("Invalid identifier path"))
+            .collect();
 
         self
     }
@@ -200,13 +203,11 @@ impl<'types> Renderer<'types> {
                 let traits = meta.derive.iter().map(|x| match x.to_string().as_ref() {
                     "Debug" => IdentPath::from_str("core::fmt::Debug").unwrap(),
                     "Hash" => IdentPath::from_str("core::hash::Hash").unwrap(),
-                    _ => IdentPath::from_ident(x.clone()),
+                    _ => x.clone(),
                 });
 
-                let as_any = IdentPath::from_parts(
-                    Some(meta.xsd_parser_crate.clone()),
-                    format_ident!("AsAny"),
-                );
+                let as_any =
+                    IdentPath::from_parts([meta.xsd_parser_crate.clone()], format_ident!("AsAny"));
 
                 traits.chain(Some(as_any)).collect()
             }


### PR DESCRIPTION
Sketch solution for #161. It looks like it passes the tests and allows for deriving a path like `specta::Type`. I'm not the best at proc macros though so this might not be the best approach.