### PR TITLE
Use the name that is passed to the serializer for `AnyElement`

### DIFF
--- a/src/pipeline/renderer/steps/quick_xml/serialize.rs
+++ b/src/pipeline/renderer/steps/quick_xml/serialize.rs
@@ -1084,6 +1084,12 @@ impl ComplexDataElement<'_> {
             quote!(false)
         };
 
+        let element_name = self
+            .meta()
+            .is_any()
+            .then(|| quote!(None))
+            .unwrap_or_else(|| quote!(Some(#field_name)));
+
         match self.occurs {
             Occurs::None => crate::unreachable!(),
             Occurs::Single => {
@@ -1092,7 +1098,7 @@ impl ComplexDataElement<'_> {
 
                 quote! {
                     *self.state = #state_ident::#variant_ident(
-                        #with_serializer::serializer(#value, Some(#field_name), #is_root)?
+                        #with_serializer::serializer(#value, #element_name, #is_root)?
                     )
                 }
             }
@@ -1106,7 +1112,7 @@ impl ComplexDataElement<'_> {
                     *self.state = #state_ident::#variant_ident(
                         #iter_serializer::new(
                             #deref_iter::new(#value),
-                            Some(#field_name),
+                            #element_name,
                             #is_root
                         )
                     )
@@ -1120,7 +1126,7 @@ impl ComplexDataElement<'_> {
                     *self.state = #state_ident::#variant_ident(
                         #iter_serializer::new(
                             #value,
-                            Some(#field_name),
+                            #element_name,
                             #is_root
                         )
                     )

--- a/tests/feature/any/expected/quick_xml.rs
+++ b/tests/feature/any/expected/quick_xml.rs
@@ -1087,7 +1087,7 @@ pub mod quick_xml_serialize {
                         None => {
                             *self.state = FooTypeSerializerState::Any0(IterSerializer::new(
                                 &self.value.any_0[..],
-                                Some("any4"),
+                                None,
                                 false,
                             ))
                         }
@@ -1107,7 +1107,7 @@ pub mod quick_xml_serialize {
                         None => {
                             *self.state = FooTypeSerializerState::Any1(IterSerializer::new(
                                 &self.value.any_1[..],
-                                Some("any5"),
+                                None,
                                 false,
                             ))
                         }
@@ -1221,7 +1221,7 @@ pub mod quick_xml_serialize {
                         }
                         super::ChoiceTypeContent::Any(x) => {
                             *self.state = ChoiceTypeContentSerializerState::Any(
-                                WithSerializer::serializer(x, Some("any2"), false)?,
+                                WithSerializer::serializer(x, None, false)?,
                             )
                         }
                     },

--- a/tests/feature/any_type/expected/quick_xml.rs
+++ b/tests/feature/any_type/expected/quick_xml.rs
@@ -648,7 +648,7 @@ pub mod quick_xml_serialize {
                         None => {
                             *self.state = AnyTypeSerializerState::Any(IterSerializer::new(
                                 &self.value.any[..],
-                                Some("any"),
+                                None,
                                 false,
                             ))
                         }

--- a/tests/feature/extension_mixed_content/expected/quick_xml.rs
+++ b/tests/feature/extension_mixed_content/expected/quick_xml.rs
@@ -530,7 +530,7 @@ pub mod quick_xml_serialize {
                             Some(event) => return Ok(Some(event)),
                             None => {
                                 *self.state = AttributeValueTypeSerializerState::Any(
-                                    IterSerializer::new(&self.value.any[..], Some("any4"), false),
+                                    IterSerializer::new(&self.value.any[..], None, false),
                                 )
                             }
                         }

--- a/tests/schema/xccdf_1_2/expected/quick_xml.rs
+++ b/tests/schema/xccdf_1_2/expected/quick_xml.rs
@@ -34680,7 +34680,7 @@ pub mod cdf {
                         DcStatusTypeSerializerState::Init__ => {
                             *self.state = DcStatusTypeSerializerState::Any(IterSerializer::new(
                                 &self.value.any[..],
-                                Some("any6"),
+                                None,
                                 false,
                             ));
                             let mut bytes = BytesStart::new(self.name);
@@ -34887,7 +34887,7 @@ pub mod cdf {
                             }
                             super::HtmlTextWithSubTypeContent::Any(x) => {
                                 *self.state = HtmlTextWithSubTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any17"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::HtmlTextWithSubTypeContent::Text(x) => {
@@ -34982,16 +34982,16 @@ pub mod cdf {
                             write_attrib_opt(&mut bytes, "lang", &self.value.lang)?;
                             return Ok(Some(Event::Start(bytes)));
                         }
-                        NoticeTypeSerializerState::TextBefore(x) => match x.next().transpose()? {
-                            Some(event) => return Ok(Some(event)),
-                            None => {
-                                *self.state = NoticeTypeSerializerState::Any(IterSerializer::new(
-                                    &self.value.any[..],
-                                    Some("any4"),
-                                    false,
-                                ))
+                        NoticeTypeSerializerState::TextBefore(x) => {
+                            match x.next().transpose()? {
+                                Some(event) => return Ok(Some(event)),
+                                None => {
+                                    *self.state = NoticeTypeSerializerState::Any(
+                                        IterSerializer::new(&self.value.any[..], None, false),
+                                    )
+                                }
                             }
-                        },
+                        }
                         NoticeTypeSerializerState::Any(x) => match x.next().transpose()? {
                             Some(event) => return Ok(Some(event)),
                             None => *self.state = NoticeTypeSerializerState::End__,
@@ -35065,12 +35065,9 @@ pub mod cdf {
                             match x.next().transpose()? {
                                 Some(event) => return Ok(Some(event)),
                                 None => {
-                                    *self.state =
-                                        ReferenceTypeSerializerState::Any(IterSerializer::new(
-                                            &self.value.any[..],
-                                            Some("any8"),
-                                            false,
-                                        ))
+                                    *self.state = ReferenceTypeSerializerState::Any(
+                                        IterSerializer::new(&self.value.any[..], None, false),
+                                    )
                                 }
                             }
                         }
@@ -35304,7 +35301,7 @@ pub mod cdf {
                         MetadataTypeSerializerState::Init__ => {
                             *self.state = MetadataTypeSerializerState::Any(IterSerializer::new(
                                 &self.value.any[..],
-                                Some("any12"),
+                                None,
                                 false,
                             ));
                             let mut bytes = BytesStart::new(self.name);
@@ -36920,7 +36917,7 @@ pub mod cdf {
                             }
                             super::TestResultTypeContent::Any(x) => {
                                 *self.state = TestResultTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any54"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::TestResultTypeContent::Platform(x) => {
@@ -37117,7 +37114,7 @@ pub mod cdf {
                     match &mut *self.state {
                         SignatureTypeSerializerState::Init__ => {
                             *self.state = SignatureTypeSerializerState::Any(
-                                WithSerializer::serializer(&self.value.any, Some("any10"), false)?,
+                                WithSerializer::serializer(&self.value.any, None, false)?,
                             );
                             let mut bytes = BytesStart::new(self.name);
                             if self.is_root {
@@ -37852,7 +37849,7 @@ pub mod cdf {
                             }
                             super::WarningTypeContent::Any(x) => {
                                 *self.state = WarningTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any17"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::WarningTypeContent::Text(x) => {
@@ -38545,7 +38542,7 @@ pub mod cdf {
                             }
                             super::ProfileNoteTypeContent::Any(x) => {
                                 *self.state = ProfileNoteTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any19"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::ProfileNoteTypeContent::Text(x) => {
@@ -38689,7 +38686,7 @@ pub mod cdf {
                             }
                             super::FixTextTypeContent::Any(x) => {
                                 *self.state = FixTextTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any17"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::FixTextTypeContent::Text(x) => {
@@ -39880,12 +39877,9 @@ pub mod cdf {
                             match x.next().transpose()? {
                                 Some(event) => return Ok(Some(event)),
                                 None => {
-                                    *self.state =
-                                        CheckImportTypeSerializerState::Any(IterSerializer::new(
-                                            self.value.any.as_ref(),
-                                            Some("any36"),
-                                            false,
-                                        ))
+                                    *self.state = CheckImportTypeSerializerState::Any(
+                                        IterSerializer::new(self.value.any.as_ref(), None, false),
+                                    )
                                 }
                             }
                         }
@@ -40127,7 +40121,7 @@ pub mod cdf {
                         CheckContentTypeContentSerializerState::Init__ => match self.value {
                             super::CheckContentTypeContent::Any(x) => {
                                 *self.state = CheckContentTypeContentSerializerState::Any(
-                                    WithSerializer::serializer(x, Some("any38"), false)?,
+                                    WithSerializer::serializer(x, None, false)?,
                                 )
                             }
                             super::CheckContentTypeContent::Text(x) => {


### PR DESCRIPTION
`AnyElement` is used in two contexts:
- If the schema defines a `xs:any` element, or
- If the schema defines a explicit element without a concrete type.

While it is correct for the sooner, to not use the name from the element definition (because it is a generated name like "anyX"), the later should make use of the correct element name.
Instead of silently dropping the name in the `AnyElement` serializer, we now use it to serialize the correct element. To avoid conflicts with the `xs:any` elements the code generator for the serializer does not pass the name to the serializer of the element was a `xs:any` element.

Related to #158 