### PR TITLE
Fix issue with simple types that have a complex base

### DIFF
--- a/xsd-parser/src/models/meta/reference.rs
+++ b/xsd-parser/src/models/meta/reference.rs
@@ -72,6 +72,32 @@ impl ReferenceMeta {
 
         self
     }
+
+    /// Returns `true` if this type is emptiable, `false` otherwise.
+    ///
+    /// Emptiable means that the type may not have any element.
+    #[must_use]
+    pub fn is_emptiable(&self, types: &MetaTypes) -> bool {
+        if self.min_occurs == 0 {
+            return true;
+        }
+
+        types
+            .items
+            .get(&self.type_)
+            .is_none_or(|ty| ty.is_emptiable(types))
+    }
+
+    /// Returns `true` if this type is mixed, `false` otherwise.
+    ///
+    /// Mixed means, that the type also accepts text intermixed with it's elements.
+    #[must_use]
+    pub fn is_mixed(&self, types: &MetaTypes) -> bool {
+        types
+            .items
+            .get(&self.type_)
+            .is_some_and(|ty| ty.is_mixed(types))
+    }
 }
 
 impl TypeEq for ReferenceMeta {

--- a/xsd-parser/src/models/meta/type_.rs
+++ b/xsd-parser/src/models/meta/type_.rs
@@ -138,6 +138,22 @@ impl MetaType {
     pub fn form(&self) -> FormChoiceType {
         self.form.unwrap_or(FormChoiceType::Unqualified)
     }
+
+    /// Returns `true` if this type is emptiable, `false` otherwise.
+    ///
+    /// Emptiable means that the type may not have any element.
+    #[must_use]
+    pub fn is_emptiable(&self, types: &MetaTypes) -> bool {
+        self.variant.is_emptiable(types)
+    }
+
+    /// Returns `true` if this type is mixed, `false` otherwise.
+    ///
+    /// Mixed means, that the type also accepts text intermixed with it's elements.
+    #[must_use]
+    pub fn is_mixed(&self, types: &MetaTypes) -> bool {
+        self.variant.is_mixed(types)
+    }
 }
 
 impl Deref for MetaType {
@@ -196,6 +212,42 @@ impl TypeEq for MetaType {
             (ComplexType(x), ComplexType(y)) => x.type_eq(y, types),
             (SimpleType(x), SimpleType(y)) => x.type_eq(y, types),
             (_, _) => false,
+        }
+    }
+}
+
+/* MetaTypeVariant */
+
+impl MetaTypeVariant {
+    /// Returns `true` if this type is emptiable, `false` otherwise.
+    ///
+    /// Emptiable means that the type may not have any element.
+    #[must_use]
+    pub fn is_emptiable(&self, types: &MetaTypes) -> bool {
+        match self {
+            Self::Union(_) | Self::BuildIn(_) | Self::Enumeration(_) | Self::SimpleType(_) => true,
+            Self::Custom(_) | Self::Dynamic(_) => false,
+            Self::Reference(x) => x.is_emptiable(types),
+            Self::All(x) | Self::Choice(x) | Self::Sequence(x) => x.is_emptiable(types),
+            Self::ComplexType(x) => x.is_emptiable(types),
+        }
+    }
+
+    /// Returns `true` if this type is mixed, `false` otherwise.
+    ///
+    /// Mixed means, that the type also accepts text intermixed with it's elements.
+    #[must_use]
+    pub fn is_mixed(&self, types: &MetaTypes) -> bool {
+        match self {
+            Self::Union(_)
+            | Self::BuildIn(_)
+            | Self::Enumeration(_)
+            | Self::SimpleType(_)
+            | Self::Custom(_)
+            | Self::Dynamic(_) => false,
+            Self::Reference(x) => x.is_mixed(types),
+            Self::All(x) | Self::Choice(x) | Self::Sequence(x) => x.is_mixed,
+            Self::ComplexType(x) => x.is_mixed,
         }
     }
 }

--- a/xsd-parser/tests/feature/mod.rs
+++ b/xsd-parser/tests/feature/mod.rs
@@ -52,6 +52,7 @@ mod sequence_with_choice_nested;
 mod simple_content;
 mod simple_content_with_extension;
 mod simple_type;
+mod simple_type_emptiable_complex_base;
 mod simple_type_max_length;
 mod static_list;
 mod tuple_with_integer;

--- a/xsd-parser/tests/feature/simple_type_emptiable_complex_base/expected/default.rs
+++ b/xsd-parser/tests/feature/simple_type_emptiable_complex_base/expected/default.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub struct SimpleLiteralType {
+    pub lang: Option<String>,
+}
+#[derive(Debug)]
+pub struct W3CdtfType {
+    pub content: String,
+}

--- a/xsd-parser/tests/feature/simple_type_emptiable_complex_base/mod.rs
+++ b/xsd-parser/tests/feature/simple_type_emptiable_complex_base/mod.rs
@@ -1,0 +1,28 @@
+use xsd_parser::{Config, IdentType};
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default().with_generate([
+        (IdentType::Type, "SimpleLiteral"),
+        (IdentType::Type, "W3CDTF"),
+    ])
+}
+
+/* default */
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/simple_type_emptiable_complex_base/schema.xsd",
+        "tests/feature/simple_type_emptiable_complex_base/expected/default.rs",
+        config(),
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}

--- a/xsd-parser/tests/feature/simple_type_emptiable_complex_base/schema.xsd
+++ b/xsd-parser/tests/feature/simple_type_emptiable_complex_base/schema.xsd
@@ -1,0 +1,22 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:complexType name="SimpleLiteral">
+        <xs:complexContent mixed="true">
+            <xs:restriction base="xs:anyType">
+                <xs:sequence>
+                    <xs:any processContents="lax" minOccurs="0" maxOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="lang" type="xs:string"  use="optional"/>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="W3CDTF">
+        <xs:simpleContent>
+            <xs:restriction base="SimpleLiteral">
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:gYear xs:gYearMonth xs:date xs:dateTime"/>
+                </xs:simpleType>
+                <xs:attribute name="lang" type="xs:string" use="prohibited"/>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Simple types or complex types with simple content may be based on complex types with complex content, if this type or content is mixed and emptiable. If so, these types are simply interpreted as string.

Related to #187 