### PR TITLE
Fix windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,3 @@ similar_names = "allow"
 single_match_else = "allow"
 struct_field_names = "allow"
 uninlined_format_args = "allow"
-
-[workspace.package.metadata.docs.rs]
-all-features = true

--- a/xsd-parser-types/Cargo.toml
+++ b/xsd-parser-types/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = [ ]
 # Enable support for async `quick-xml` de-/serialization
@@ -33,7 +36,4 @@ thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [lints]
-workspace = true
-
-[package.metadata.docs.rs]
 workspace = true

--- a/xsd-parser/Cargo.toml
+++ b/xsd-parser/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 # Enable support for web resolvers
 web-resolver = [ "reqwest" ]
@@ -59,7 +62,4 @@ base64 = { workspace = true }
 regex = { workspace = true }
 
 [lints]
-workspace = true
-
-[package.metadata.docs.rs]
 workspace = true


### PR DESCRIPTION
When referencing the repository directly and not the crate on crates.io the build script is broken on windows because the symlink to the `doc` directory inside `xsd-parser` is broken. To fix this we try to resolve the file in the current crate directory and in it's parent directory inside the build script.