### PR TITLE
Fix WithNamespaceTrait generating conflicting impls for type aliases

### DIFF
--- a/xsd-parser/src/pipeline/renderer/steps/with_namespace_trait.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/with_namespace_trait.rs
@@ -1,6 +1,7 @@
 use proc_macro2::{Ident as Ident2, TokenStream};
 use quote::quote;
 
+use crate::config::TypedefMode;
 use crate::models::data::{
     ComplexData, ComplexDataEnum, ComplexDataStruct, DynamicData, EnumerationData, ReferenceData,
     SimpleData, UnionData,
@@ -55,6 +56,12 @@ impl DynamicData<'_> {
 
 impl ReferenceData<'_> {
     pub(crate) fn render_with_namespace_trait(&self, ctx: &mut Context<'_, '_>) {
+        // Skip generating impl for type aliases - they share the underlying type's impl.
+        // Only newtypes (tuple structs) need their own impl.
+        if self.mode == TypedefMode::Typedef {
+            return;
+        }
+
         if let Some(code) = render_trait_with_namespace(ctx, &self.type_ident) {
             ctx.current_module().append(code);
         }

--- a/xsd-parser/tests/feature/mod.rs
+++ b/xsd-parser/tests/feature/mod.rs
@@ -65,4 +65,5 @@ mod tuple_with_vec;
 mod type_loops;
 mod type_name_clash;
 mod union;
+mod with_namespace_trait;
 mod xsd_string;

--- a/xsd-parser/tests/feature/with_namespace_trait/expected/default.rs
+++ b/xsd-parser/tests/feature/with_namespace_trait/expected/default.rs
@@ -1,0 +1,11 @@
+pub type Message = MessageType;
+#[derive(Debug)]
+pub struct MessageType;
+impl xsd_parser_types::WithNamespace for MessageType {
+    fn prefix() -> Option<&'static str> {
+        Some("test")
+    }
+    fn namespace() -> Option<&'static str> {
+        Some("http://example.com/test/01p00")
+    }
+}

--- a/xsd-parser/tests/feature/with_namespace_trait/mod.rs
+++ b/xsd-parser/tests/feature/with_namespace_trait/mod.rs
@@ -1,0 +1,38 @@
+use xsd_parser::config::{NamespaceIdent, RenderStep};
+use xsd_parser::{Config, IdentType};
+use xsd_parser_types::misc::Namespace;
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default()
+        .with_generate([(
+            IdentType::Element,
+            Some(NamespaceIdent::Namespace(Namespace::new_const(
+                b"http://example.com/test/01p00",
+            ))),
+            "Message",
+        )])
+        .with_render_steps([RenderStep::Types, RenderStep::WithNamespaceTrait])
+}
+
+/* default */
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/with_namespace_trait/schema.xsd",
+        "tests/feature/with_namespace_trait/expected/default.rs",
+        config(),
+    );
+}
+
+/// Verify the generated code compiles without conflicting trait implementations.
+/// This test catches the bug where WithNamespaceTrait generates duplicate impls
+/// for both a type alias and its underlying struct.
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}

--- a/xsd-parser/tests/feature/with_namespace_trait/schema.xsd
+++ b/xsd-parser/tests/feature/with_namespace_trait/schema.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:test="http://example.com/test/01p00"
+    targetNamespace="http://example.com/test/01p00"
+    elementFormDefault="qualified">
+
+    <xsd:element name="Message">
+        <xsd:complexType />
+    </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
When RenderStep::WithNamespaceTrait was enabled, it generated impl WithNamespace for both type aliases and their underlying types, causing Rust error E0119 (conflicting implementations).

Skip generating impl for ReferenceData when mode is TypedefMode::Typedef, since type aliases share their underlying type's impl.

Closes #219 