### PR TITLE
Improve name generation

### DIFF
--- a/examples/bpmn/build.rs
+++ b/examples/bpmn/build.rs
@@ -28,7 +28,6 @@ fn main() -> Result<(), Error> {
         .set_optimizer_flags(OptimizerFlags::all())
         .set_generator_flags(GeneratorFlags::all())
         .with_type_postfix("XType")
-        // TODO .with_element_type_postfix("XElementType")
         .with_quick_xml()
         .with_generate([(
             IdentType::Element,

--- a/xsd-parser/src/lib.rs
+++ b/xsd-parser/src/lib.rs
@@ -26,6 +26,8 @@ use std::fmt::Debug;
 use std::fs::write;
 use std::io::Error as IoError;
 
+pub use proc_macro2::Ident as Ident2;
+
 pub use self::config::Config;
 pub use self::meta_types_printer::MetaTypesPrinter;
 pub use self::models::{

--- a/xsd-parser/src/models/mod.rs
+++ b/xsd-parser/src/models/mod.rs
@@ -26,4 +26,7 @@ pub use self::ident::{
 };
 pub use self::ident_cache::IdentCache;
 pub use self::name::Name;
-pub use self::naming::{ExplicitNameBuilder, ExplicitNaming, NameBuilder, Naming};
+pub use self::naming::{
+    format_ident, format_unknown_variant, unify_string, ExplicitNameBuilder, ExplicitNaming,
+    NameBuilder, Naming,
+};

--- a/xsd-parser/src/models/naming/default.rs
+++ b/xsd-parser/src/models/naming/default.rs
@@ -1,0 +1,295 @@
+use std::any::Any;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use inflector::Inflector;
+use proc_macro2::Ident as Ident2;
+
+use crate::models::{
+    meta::{MetaType, MetaTypeVariant},
+    schema::MaxOccurs,
+    TypeIdent,
+};
+use crate::traits::{NameBuilder as NameBuilderTrait, Naming as NamingTrait};
+
+use super::Name;
+
+/// Default name generation and formatting implementation.
+///
+/// This type implements the [`Naming`](NamingTrait) trait that is used for
+/// naming generation and formatting.
+#[derive(Default, Debug, Clone)]
+pub struct Naming(Arc<AtomicUsize>);
+
+impl NamingTrait for Naming {
+    fn clone_boxed(&self) -> Box<dyn NamingTrait> {
+        Box::new(self.clone())
+    }
+
+    fn builder(&self) -> Box<dyn NameBuilderTrait> {
+        Box::new(NameBuilder::new(self.0.clone(), self.clone_boxed()))
+    }
+
+    fn unify(&self, s: &str) -> String {
+        super::unify_string(s)
+    }
+
+    fn make_type_name(&self, postfixes: &[String], ty: &MetaType, ident: &TypeIdent) -> Name {
+        if let MetaTypeVariant::Reference(ti) = &ty.variant {
+            if ident.name.is_generated() && ti.type_.name.is_named() {
+                let s = self.format_type_name(ti.type_.name.as_str());
+
+                if ti.max_occurs > MaxOccurs::Bounded(1) {
+                    return Name::new_generated(format!("{s}List"));
+                } else if ti.min_occurs == 0 {
+                    return Name::new_generated(format!("{s}Opt"));
+                }
+            }
+        }
+
+        let postfix = postfixes
+            .get(ident.type_ as usize)
+            .map_or("", |s| s.as_str());
+
+        let s = self.format_type_name(ident.name.as_str());
+
+        if s.ends_with(postfix) {
+            ident.name.clone()
+        } else {
+            Name::new_generated(format!("{s}{postfix}"))
+        }
+    }
+
+    fn make_unknown_variant(&self, id: usize) -> Ident2 {
+        super::format_unknown_variant(id)
+    }
+
+    fn format_module_name(&self, s: &str) -> String {
+        let s = self.unify(s).to_snake_case();
+
+        super::format_ident(s)
+    }
+
+    fn format_type_name(&self, s: &str) -> String {
+        let s = self.unify(s);
+
+        super::format_ident(s)
+    }
+
+    fn format_field_name(&self, s: &str) -> String {
+        let s = self.unify(s).to_snake_case();
+
+        super::format_ident(s)
+    }
+
+    fn format_variant_name(&self, s: &str) -> String {
+        let s = self.unify(s);
+
+        super::format_ident(s)
+    }
+}
+
+/// Default implementation for the [`NameBuilder`](NameBuilderTrait) trait.
+#[must_use]
+#[derive(Debug)]
+pub struct NameBuilder {
+    id: Arc<AtomicUsize>,
+    my_id: Option<usize>,
+    with_id: bool,
+    generated: bool,
+
+    name: Option<String>,
+    extension: Option<String>,
+
+    naming: Box<dyn NamingTrait>,
+}
+
+impl NameBuilder {
+    /// Create a new [`NameBuilder`] instance.
+    ///
+    /// The passed `id` is used to generate unique ids for unnamed types.
+    pub fn new(id: Arc<AtomicUsize>, naming: Box<dyn NamingTrait>) -> Self {
+        Self {
+            id,
+            my_id: None,
+            with_id: true,
+            generated: false,
+            name: None,
+            extension: None,
+            naming,
+        }
+    }
+}
+
+impl Clone for NameBuilder {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id.clone(),
+            my_id: self.my_id,
+            with_id: self.with_id,
+            generated: self.generated,
+            name: self.name.clone(),
+            extension: self.extension.clone(),
+            naming: self.naming.clone_boxed(),
+        }
+    }
+}
+
+impl NameBuilderTrait for NameBuilder {
+    fn finish(&self) -> Name {
+        let Self {
+            id,
+            my_id,
+            with_id,
+            mut generated,
+            name,
+            extension,
+            naming,
+        } = self;
+
+        let mut ret = String::new();
+        if let Some(s) = extension {
+            generated = true;
+            ret.push_str(&naming.unify(s));
+        }
+
+        if let Some(s) = name {
+            if ret.is_empty() {
+                ret.push_str(s);
+            } else {
+                ret.push_str(&naming.unify(s));
+            }
+        }
+
+        if ret.is_empty() {
+            generated = true;
+            ret.push_str("Unnamed");
+        }
+
+        if *with_id {
+            generated = true;
+            let id = my_id.unwrap_or_else(|| id.fetch_add(1, Ordering::Relaxed));
+            ret = format!("{ret}{id}");
+        }
+
+        if generated {
+            Name::new_generated(ret)
+        } else {
+            Name::new_named(ret)
+        }
+    }
+
+    fn merge(&mut self, other: &dyn NameBuilderTrait) {
+        let other: &Self = (other as &dyn Any).downcast_ref().unwrap();
+
+        if let Some(name) = other.name.clone() {
+            self.name.get_or_insert(name);
+            self.with_id = other.with_id;
+            self.generated = other.generated;
+
+            if let Some(id) = other.my_id {
+                self.with_id = other.with_id;
+                self.my_id.get_or_insert(id);
+            }
+
+            if let Some(ext) = other.extension.clone() {
+                self.extension.get_or_insert(ext);
+            }
+        }
+    }
+
+    fn clone_boxed(&self) -> Box<dyn NameBuilderTrait> {
+        Box::new(self.clone())
+    }
+
+    fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    fn has_extension(&self) -> bool {
+        self.extension.is_some()
+    }
+
+    fn set_name(&mut self, name: String) {
+        self.name = Some(name);
+    }
+
+    fn set_with_id(&mut self, value: bool) {
+        self.with_id = value;
+    }
+
+    fn set_generated(&mut self, value: bool) {
+        self.generated = value;
+    }
+
+    fn add_extension(&mut self, replace: bool, extension: String) {
+        let s = self.naming.unify(&extension);
+
+        if replace {
+            self.extension = Some(s);
+        } else if let Some(prefix) = &self.extension {
+            self.extension = Some(format!("{s}{prefix}"));
+        } else {
+            self.extension = Some(s);
+        }
+    }
+
+    fn strip_suffix(&mut self, suffix: &str) {
+        if let Some(s) = &mut self.name {
+            if let Some(x) = s.strip_suffix(suffix) {
+                *s = x.into();
+            }
+        }
+
+        if let Some(s) = &mut self.extension {
+            if let Some(x) = s.strip_suffix(suffix) {
+                *s = x.into();
+            }
+        }
+    }
+
+    fn generate_unique_id(&mut self) {
+        if self.my_id.is_none() {
+            self.my_id = Some(self.id.fetch_add(1, Ordering::Release));
+        }
+    }
+
+    fn prepare_type_name(&mut self) {
+        self.strip_suffix("Type");
+        self.strip_suffix("Content");
+    }
+
+    fn prepare_field_name(&mut self) {
+        self.strip_suffix("Type");
+        self.strip_suffix("Content");
+    }
+
+    fn prepare_content_type_name(&mut self) {
+        self.strip_suffix("Type");
+        self.strip_suffix("Content");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::Naming as _;
+
+    use super::Naming;
+
+    #[test]
+    fn default_naming() {
+        let naming = Naming::default();
+
+        assert_eq!("_", naming.unify("+"));
+        assert_eq!("FuuBarBaz", naming.unify("Fuu_BAR_BAZ"));
+        assert_eq!("FuuBarBaz", naming.unify("fuu_bar_baz"));
+        assert_eq!("FuuBarBaz", naming.unify("fuu+Bar-BAZ"));
+
+        assert_eq!("QName", naming.unify("QName"));
+        assert_eq!("QName", naming.format_type_name("QName"));
+        assert_eq!("QName", naming.format_variant_name("QName"));
+        assert_eq!("q_name", naming.format_field_name("QName"));
+    }
+}

--- a/xsd-parser/src/pipeline/interpreter/variant_builder.rs
+++ b/xsd-parser/src/pipeline/interpreter/variant_builder.rs
@@ -731,7 +731,7 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
                     .state
                     .name_builder()
                     .extend(true, ty.name.clone())
-                    .auto_extend(true, false, self.state);
+                    .auto_extend(true, false, self.state); // TODO
                 let type_name = if type_name.has_extension() {
                     type_name.with_id(false)
                 } else {

--- a/xsd-parser/src/pipeline/optimizer/dynamic_to_choice.rs
+++ b/xsd-parser/src/pipeline/optimizer/dynamic_to_choice.rs
@@ -62,7 +62,11 @@ impl Optimizer {
 
             match self.types.items.entry(content_ident) {
                 Entry::Vacant(e) => {
-                    e.insert(MetaType::new(MetaTypeVariant::Choice(si)));
+                    e.insert(MetaType::new(if si.elements.is_empty() {
+                        MetaTypeVariant::Sequence(si)
+                    } else {
+                        MetaTypeVariant::Choice(si)
+                    }));
                 }
                 Entry::Occupied(_) => crate::unreachable!(),
             }

--- a/xsd-parser/tests/feature/mod.rs
+++ b/xsd-parser/tests/feature/mod.rs
@@ -61,6 +61,7 @@ mod simple_type;
 mod simple_type_emptiable_complex_base;
 mod simple_type_max_length;
 mod static_list;
+mod trailing_underscore_group;
 mod tuple_with_integer;
 mod tuple_with_string;
 mod tuple_with_vec;

--- a/xsd-parser/tests/feature/trailing_underscore_group/expected/default.rs
+++ b/xsd-parser/tests/feature/trailing_underscore_group/expected/default.rs
@@ -1,0 +1,68 @@
+#[derive(Debug, Default)]
+pub struct ENTITIESType(pub Vec<String>);
+#[derive(Debug, Default)]
+pub struct ENTITYType(pub Vec<String>);
+pub type IDType = String;
+pub type IDREFType = String;
+#[derive(Debug, Default)]
+pub struct IDREFSType(pub Vec<String>);
+pub type NCNameType = String;
+pub type NMTOKENType = String;
+#[derive(Debug, Default)]
+pub struct NMTOKENSType(pub Vec<String>);
+pub type NOTATIONType = String;
+pub type NameType = String;
+pub type QNameType = String;
+pub type anySimpleTypeType = String;
+#[derive(Debug)]
+pub struct anyTypeType;
+pub type anyURIType = String;
+pub type base64BinaryType = String;
+pub type booleanType = bool;
+pub type byteType = i8;
+pub type dateType = String;
+pub type dateTimeType = String;
+pub type decimalType = f64;
+pub type doubleType = f64;
+pub type durationType = String;
+pub type floatType = f32;
+pub type gDayType = String;
+pub type gMonthType = String;
+pub type gMonthDayType = String;
+pub type gYearType = String;
+pub type gYearMonthType = String;
+pub type hexBinaryType = String;
+pub type intType = i32;
+pub type integerType = i32;
+pub type languageType = String;
+pub type longType = i64;
+pub type negativeIntegerType = isize;
+pub type nonNegativeIntegerType = usize;
+pub type nonPositiveIntegerType = isize;
+pub type normalizedStringType = String;
+pub type positiveIntegerType = usize;
+pub type shortType = i16;
+pub type stringType = String;
+pub type timeType = String;
+pub type tokenType = String;
+pub type unsignedByteType = u8;
+pub type unsignedIntType = u32;
+pub type unsignedLongType = u64;
+pub type unsignedShortType = u16;
+#[derive(Debug)]
+pub struct BaseType {
+    pub my_group_1: Base_MyGroupType,
+    pub my_group_2: BaseMyGroupType,
+}
+#[derive(Debug)]
+pub struct Base_Type {
+    pub my_group: Base_MyGroupType,
+}
+#[derive(Debug)]
+pub struct Base_MyGroupType {
+    pub name: Option<String>,
+}
+#[derive(Debug)]
+pub struct BaseMyGroupType {
+    pub name: Option<String>,
+}

--- a/xsd-parser/tests/feature/trailing_underscore_group/mod.rs
+++ b/xsd-parser/tests/feature/trailing_underscore_group/mod.rs
@@ -1,0 +1,22 @@
+use crate::utils::{generate_test, ConfigEx};
+use xsd_parser::{models::ExplicitNaming, Config};
+
+fn config() -> Config {
+    Config::test_default().with_naming(ExplicitNaming::new().unify_names(false))
+}
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/trailing_underscore_group/schema.xsd",
+        "tests/feature/trailing_underscore_group/expected/default.rs",
+        config(),
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(non_camel_case_types)]
+
+    include!("expected/default.rs");
+}

--- a/xsd-parser/tests/feature/trailing_underscore_group/schema.xsd
+++ b/xsd-parser/tests/feature/trailing_underscore_group/schema.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test for issue #197: Duplicate names when types differ only by trailing underscore -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="http://example.org/test"
+            targetNamespace="http://example.org/test"
+            elementFormDefault="qualified">
+
+  <xsd:group name="MyGroup">
+    <xsd:sequence>
+      <xsd:element name="Name" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:complexType name="Base_">
+    <xsd:sequence>
+      <xsd:group ref="MyGroup"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="Base">
+    <xsd:complexContent>
+      <xsd:restriction base="Base_">
+        <xsd:sequence>
+          <xsd:group ref="MyGroup"/>
+        </xsd:sequence>
+      </xsd:restriction>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
Generating suitable names for generated types is a complex task, and the current implementation has some shortcomings. This commit improves the existing `Naming` trait and its implementations to make it easier to use.

Related to #207 