### PR TITLE
Implement `DerivedTypeMeta` to store meta information for derived types

### DIFF
--- a/examples/vsme/.gitignore
+++ b/examples/vsme/.gitignore
@@ -1,1 +1,1 @@
-src/vsme
+src/schema

--- a/examples/vsme/build.rs
+++ b/examples/vsme/build.rs
@@ -38,9 +38,9 @@ fn main() -> Result<(), Error> {
     let modules = generate_modules(config)?;
 
     // Write the generated code to the module directory specified by Cargo.
-    let target_dir = cargo_dir.join("src/vsme");
+    let target_dir = cargo_dir.join("src/schema");
     let _ = remove_dir_all(&target_dir);
-    create_dir_all(&target_dir).context("Unable to create `src/vsme` directory!")?;
+    create_dir_all(&target_dir).context("Unable to create `src/schema` directory!")?;
     modules
         .write_to_files(&target_dir)
         .context("Error while writing generated code")?;

--- a/examples/vsme/src/main.rs
+++ b/examples/vsme/src/main.rs
@@ -2,7 +2,7 @@
 
 #[allow(clippy::all, dead_code, missing_docs, unreachable_pub, unused)]
 #[rustfmt::skip]
-mod vsme;
+mod schema;
 
 use std::fs::File;
 use std::io::BufReader;
@@ -10,7 +10,7 @@ use std::io::BufReader;
 use anyhow::{Context, Error};
 use xsd_parser_types::quick_xml::{DeserializeSync, IoReader, XmlReader};
 
-use vsme::xbrli::Xbrl;
+use schema::xbrli::Xbrl;
 
 fn main() -> Result<(), Error> {
     let input_file =

--- a/xsd-parser/src/lib.rs
+++ b/xsd-parser/src/lib.rs
@@ -284,18 +284,25 @@ pub fn exec_optimizer(config: OptimizerConfig, types: MetaTypes) -> Result<MetaT
     );
     exec!(REMOVE_EMPTY_ENUM_VARIANTS, remove_empty_enum_variants);
     exec!(REMOVE_EMPTY_ENUMS, remove_empty_enums);
-    exec!(
-        REMOVE_DUPLICATE_UNION_VARIANTS,
-        remove_duplicate_union_variants
-    );
-    exec!(REMOVE_EMPTY_UNIONS, remove_empty_unions);
     exec!(CONVERT_DYNAMIC_TO_CHOICE, convert_dynamic_to_choice);
     exec!(FLATTEN_COMPLEX_TYPES, flatten_complex_types);
     exec!(FLATTEN_UNIONS, flatten_unions);
     exec!(MERGE_ENUM_UNIONS, merge_enum_unions);
     exec!(RESOLVE_TYPEDEFS, resolve_typedefs);
+    exec!(
+        REMOVE_DUPLICATE_UNION_VARIANTS,
+        remove_duplicate_union_variants
+    );
+    exec!(REMOVE_EMPTY_UNIONS, remove_empty_unions);
     exec!(REMOVE_DUPLICATES, remove_duplicates);
     exec!(RESOLVE_TYPEDEFS, resolve_typedefs);
+    exec!(REMOVE_EMPTY_ENUM_VARIANTS, remove_empty_enum_variants);
+    exec!(REMOVE_EMPTY_ENUMS, remove_empty_enums);
+    exec!(
+        REMOVE_DUPLICATE_UNION_VARIANTS,
+        remove_duplicate_union_variants
+    );
+    exec!(REMOVE_EMPTY_UNIONS, remove_empty_unions);
     exec!(MERGE_CHOICE_CARDINALITIES, merge_choice_cardinalities);
     exec!(SIMPLIFY_MIXED_TYPES, simplify_mixed_types);
 

--- a/xsd-parser/src/meta_types_printer.rs
+++ b/xsd-parser/src/meta_types_printer.rs
@@ -195,8 +195,8 @@ impl<'a> MetaTypesPrinter<'a> {
 
                 s.level += 1;
 
-                for ty in &*x.derived_types {
-                    indentln!("{}", ty);
+                for meta in &*x.derived_types {
+                    indentln!("{}", meta.type_);
                 }
 
                 s.level -= 2;

--- a/xsd-parser/src/models/meta/dynamic.rs
+++ b/xsd-parser/src/models/meta/dynamic.rs
@@ -1,6 +1,6 @@
 //! Contains the [`DynamicMeta`] type information and all related types.
 
-use std::hash::Hasher;
+use std::hash::{Hash, Hasher};
 
 use crate::models::TypeIdent;
 
@@ -13,7 +13,17 @@ pub struct DynamicMeta {
     pub type_: Option<TypeIdent>,
 
     /// List of derived types.
-    pub derived_types: Vec<TypeIdent>,
+    pub derived_types: Vec<DerivedTypeMeta>,
+}
+
+/// Meta^ information about a derived type.
+#[derive(Debug, Clone)]
+pub struct DerivedTypeMeta {
+    /// Identifier of the derived type.
+    pub type_: TypeIdent,
+
+    /// Name of the element to use inside the generated code.
+    pub display_name: Option<String>,
 }
 
 impl TypeEq for DynamicMeta {
@@ -35,5 +45,37 @@ impl TypeEq for DynamicMeta {
 
         type_.type_eq(&other.type_, types)
             && TypeEq::type_eq_iter(derived_types.iter(), other.derived_types.iter(), types)
+    }
+}
+
+impl DerivedTypeMeta {
+    /// Creates a new [`DerivedTypeMeta`] instance with the given `type_`.
+    #[must_use]
+    pub fn new(type_: TypeIdent) -> Self {
+        Self {
+            type_,
+            display_name: None,
+        }
+    }
+}
+
+impl TypeEq for DerivedTypeMeta {
+    fn type_hash<H: Hasher>(&self, hasher: &mut H, types: &MetaTypes) {
+        let Self {
+            type_,
+            display_name,
+        } = self;
+
+        type_.type_hash(hasher, types);
+        display_name.hash(hasher);
+    }
+
+    fn type_eq(&self, other: &Self, types: &MetaTypes) -> bool {
+        let Self {
+            type_,
+            display_name,
+        } = self;
+
+        type_.type_eq(&other.type_, types) && display_name == &other.display_name
     }
 }

--- a/xsd-parser/src/models/meta/mod.rs
+++ b/xsd-parser/src/models/meta/mod.rs
@@ -25,7 +25,7 @@ pub use self::attribute::{AnyAttributeMeta, AttributeMeta, AttributeMetaVariant,
 pub use self::base::Base;
 pub use self::complex::{ComplexMeta, GroupMeta};
 pub use self::custom::{CustomDefaultImpl, CustomMeta, CustomMetaNamespace};
-pub use self::dynamic::DynamicMeta;
+pub use self::dynamic::{DerivedTypeMeta, DynamicMeta};
 pub use self::element::{AnyMeta, ElementMeta, ElementMetaVariant, ElementMode, ElementsMeta};
 pub use self::enumeration::{EnumerationMeta, EnumerationMetaVariant, EnumerationMetaVariants};
 pub use self::reference::ReferenceMeta;

--- a/xsd-parser/src/pipeline/generator/state.rs
+++ b/xsd-parser/src/pipeline/generator/state.rs
@@ -69,15 +69,15 @@ impl TraitInfos {
                 continue;
             };
 
-            for type_ident in &ai.derived_types {
+            for meta in &ai.derived_types {
                 ret.0
-                    .entry(type_ident.clone())
+                    .entry(meta.type_.clone())
                     .or_default()
                     .traits_all
                     .insert(base_ident.clone());
 
                 #[allow(clippy::single_match)]
-                match types.get_variant(type_ident) {
+                match types.get_variant(&meta.type_) {
                     Some(MetaTypeVariant::Dynamic(DynamicMeta {
                         type_: Some(type_ident),
                         ..

--- a/xsd-parser/src/pipeline/interpreter/post_process.rs
+++ b/xsd-parser/src/pipeline/interpreter/post_process.rs
@@ -1,61 +1,102 @@
 use crate::models::{
-    meta::{ElementMeta, GroupMeta, MetaTypeVariant, MetaTypes},
-    schema::{NamespaceInfo, Schemas},
+    meta::{DynamicMeta, GroupMeta, MetaTypeVariant, MetaTypes},
+    schema::{NamespaceId, NamespaceInfo, Schemas},
 };
 
 pub(super) fn fix_element_naming_conflicts(schemas: &Schemas, types: &mut MetaTypes) {
     for type_ in types.items.values_mut() {
-        if let MetaTypeVariant::All(gm)
-        | MetaTypeVariant::Choice(gm)
-        | MetaTypeVariant::Sequence(gm) = &mut type_.variant
-        {
-            fix_group_naming_conflicts(schemas, gm);
+        match &mut type_.variant {
+            MetaTypeVariant::All(x) | MetaTypeVariant::Choice(x) | MetaTypeVariant::Sequence(x) => {
+                fix_naming_conflicts(schemas, x);
+            }
+            MetaTypeVariant::Dynamic(x) => fix_naming_conflicts(schemas, x),
+            _ => {}
         }
     }
 }
 
-fn fix_group_naming_conflicts(schemas: &Schemas, meta: &mut GroupMeta) {
-    let len = meta.elements.len();
+fn fix_naming_conflicts<X>(schemas: &Schemas, meta: &mut X)
+where
+    X: IdentSlice,
+{
+    let len = meta.len();
     for i in 0..len {
         let mut index = 2;
         let mut ns_renamed = false;
 
         for j in i + 1..len {
-            let ident_i = &meta.elements[i].ident;
-            let ident_j = &meta.elements[j].ident;
-            if ident_i.name.as_str() == ident_j.name.as_str() {
-                if ident_i.ns == ident_j.ns {
-                    set_index_display_name(&mut meta.elements[j], &mut index);
+            let ident_i = &meta.get_ident(i);
+            let ident_j = &meta.get_ident(j);
+            if ident_i.1 == ident_j.1 {
+                if ident_i.0 == ident_j.0 {
+                    let display_name = make_index_display_name(ident_j.1, &mut index);
+                    meta.set_display_name(j, Some(display_name));
                 } else {
                     ns_renamed = true;
-                    set_ns_display_name(&mut meta.elements[j], schemas);
+
+                    let display_name = make_ns_display_name(ident_j.0, ident_j.1, schemas);
+
+                    meta.set_display_name(j, display_name);
                 }
             }
         }
 
         if ns_renamed {
-            set_ns_display_name(&mut meta.elements[i], schemas);
+            let ident = meta.get_ident(i);
+            let display_name = make_ns_display_name(ident.0, ident.1, schemas);
+            meta.set_display_name(i, display_name);
         }
     }
 }
 
-fn set_ns_display_name(el: &mut ElementMeta, schemas: &Schemas) {
+fn make_ns_display_name(ns: NamespaceId, name: &str, schemas: &Schemas) -> Option<String> {
     let prefix = schemas
-        .get_namespace_info(&el.ident.ns)
+        .get_namespace_info(&ns)
         .and_then(NamespaceInfo::name);
-    if let Some(prefix) = prefix {
-        let name = el.ident.name.as_str();
-        let name = format!("{prefix}_{name}");
 
-        el.display_name = Some(name);
+    prefix.map(|prefix| format!("{prefix}_{name}"))
+}
+
+fn make_index_display_name(name: &str, index: &mut usize) -> String {
+    let name = format!("{name}_{index}");
+
+    *index += 1;
+
+    name
+}
+
+trait IdentSlice {
+    fn len(&self) -> usize;
+    fn get_ident(&self, index: usize) -> (NamespaceId, &str);
+    fn set_display_name(&mut self, index: usize, display_name: Option<String>);
+}
+
+impl IdentSlice for GroupMeta {
+    fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    fn get_ident(&self, index: usize) -> (NamespaceId, &str) {
+        let el = &self.elements[index];
+        (el.ident.ns, el.ident.name.as_str())
+    }
+
+    fn set_display_name(&mut self, index: usize, display_name: Option<String>) {
+        self.elements[index].display_name = display_name;
     }
 }
 
-fn set_index_display_name(el: &mut ElementMeta, index: &mut usize) {
-    let name = el.ident.name.as_str();
-    let name = format!("{name}_{index}");
+impl IdentSlice for DynamicMeta {
+    fn len(&self) -> usize {
+        self.derived_types.len()
+    }
 
-    el.display_name = Some(name);
+    fn get_ident(&self, index: usize) -> (NamespaceId, &str) {
+        let type_ = &self.derived_types[index].type_;
+        (type_.ns, type_.name.as_str())
+    }
 
-    *index += 1;
+    fn set_display_name(&mut self, index: usize, display_name: Option<String>) {
+        self.derived_types[index].display_name = display_name;
+    }
 }

--- a/xsd-parser/src/pipeline/interpreter/state.rs
+++ b/xsd-parser/src/pipeline/interpreter/state.rs
@@ -312,8 +312,8 @@ impl<'a> State<'a> {
                     *ty = self.resolve_type_ident_allow_unknown(ty.clone())?;
                 }
 
-                for ty in &mut x.derived_types {
-                    *ty = self.resolve_type_ident_allow_unknown(ty.clone())?;
+                for meta in &mut x.derived_types {
+                    meta.type_ = self.resolve_type_ident_allow_unknown(meta.type_.clone())?;
                 }
             }
             MetaTypeVariant::Reference(x) => {

--- a/xsd-parser/src/pipeline/interpreter/variant_builder.rs
+++ b/xsd-parser/src/pipeline/interpreter/variant_builder.rs
@@ -5,6 +5,7 @@ use std::str::from_utf8;
 
 use tracing::instrument;
 
+use crate::models::meta::DerivedTypeMeta;
 use crate::models::{
     meta::{
         AnyAttributeMeta, AnyMeta, AttributeMeta, Base, DynamicMeta, ElementMeta,
@@ -274,7 +275,7 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
                 if let MetaTypeVariant::Reference(ti) = &mut base_ty.variant {
                     base_ty.variant = MetaTypeVariant::Dynamic(DynamicMeta {
                         type_: Some(ti.type_.clone()),
-                        derived_types: vec![ti.type_.clone()],
+                        derived_types: vec![DerivedTypeMeta::new(ti.type_.clone())],
                     });
                 }
 
@@ -282,7 +283,7 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
                     return Err(Error::ExpectedDynamicElement(base_ident.clone()));
                 };
 
-                ai.derived_types.push(ident);
+                ai.derived_types.push(DerivedTypeMeta::new(ident));
 
                 Ok(())
             })?;
@@ -730,7 +731,7 @@ impl<'a, 'schema, 'state> VariantBuilder<'a, 'schema, 'state> {
                     .state
                     .name_builder()
                     .extend(true, ty.name.clone())
-                    .auto_extend(true, false, self.state); // TODO
+                    .auto_extend(true, false, self.state);
                 let type_name = if type_name.has_extension() {
                     type_name.with_id(false)
                 } else {

--- a/xsd-parser/src/pipeline/optimizer/dynamic_to_choice.rs
+++ b/xsd-parser/src/pipeline/optimizer/dynamic_to_choice.rs
@@ -81,15 +81,22 @@ impl Optimizer {
             crate::unreachable!();
         };
 
-        for derived in &x.derived_types {
-            let derived_ty = self.types.get_resolved_type(derived).unwrap();
+        for meta in &x.derived_types {
+            let derived_ty = self.types.get_resolved_type(&meta.type_).unwrap();
             if let MetaTypeVariant::Dynamic(_) = &derived_ty.variant {
                 self.add_elements(group, derived_ty);
             } else {
                 group
                     .elements
-                    .find_or_insert(derived.to_property_ident(), |ident| {
-                        ElementMeta::new(ident, derived.clone(), ElementMode::Element, form)
+                    .find_or_insert(meta.type_.to_property_ident(), |ident| {
+                        let mut el =
+                            ElementMeta::new(ident, meta.type_.clone(), ElementMode::Element, form);
+
+                        if let Some(display_name) = &meta.display_name {
+                            el.display_name = Some(display_name.clone());
+                        }
+
+                        el
                     });
             }
         }

--- a/xsd-parser/src/pipeline/optimizer/resolve_typedefs.rs
+++ b/xsd-parser/src/pipeline/optimizer/resolve_typedefs.rs
@@ -60,8 +60,8 @@ impl Optimizer {
                 MetaTypeVariant::Dynamic(x) => {
                     x.type_ = x.type_.as_ref().map(|x| typedefs.resolve(x)).cloned();
 
-                    for x in &mut x.derived_types {
-                        *x = typedefs.resolve(x).clone();
+                    for meta in &mut x.derived_types {
+                        meta.type_ = typedefs.resolve(&meta.type_).clone();
                     }
                 }
                 MetaTypeVariant::Enumeration(x) => {
@@ -104,9 +104,9 @@ impl Optimizer {
                 continue;
             };
 
-            for derived in &mut di.derived_types {
-                if let Some(new_type) = replaced_references.get(derived) {
-                    *derived = new_type.clone();
+            for meta in &mut di.derived_types {
+                if let Some(new_type) = replaced_references.get(&meta.type_) {
+                    meta.type_ = new_type.clone();
                 }
             }
         }

--- a/xsd-parser/src/pipeline/renderer/steps/quick_xml/serialize.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/quick_xml/serialize.rs
@@ -1439,8 +1439,8 @@ impl NamespaceCollector {
                     }
                 }
                 MetaTypeVariant::Dynamic(x) => {
-                    for ident in &x.derived_types {
-                        self.merge(&mut state, types, ident, default_ns);
+                    for meta in &x.derived_types {
+                        self.merge(&mut state, types, &meta.type_, default_ns);
                     }
                 }
                 MetaTypeVariant::All(x)


### PR DESCRIPTION
Like `GroupMeta`, `DynamicMeta` may hold derived types with the same name (from different schemas), but in difference to `GroupMeta`, it does not provide meta information like the `display_name`, so we can not resolve potential naming conflicts as we do it for elements in `GroupMeta`. This commit implements `DerivedTypeMeta` which is stored in `DynamicMeta` to keep track of the derived types and it's meta information. It also resolves the issue with the naming conflicts for derived types by using setting a suitable `display_name` for conflicting names.

Related to #234