### PR TITLE
Fix missing comma separator between multiple xs:pattern PATTERNS entries

### DIFF
--- a/xsd-parser/src/pipeline/renderer/steps/mod.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/mod.rs
@@ -240,7 +240,7 @@ impl ConstrainsData<'_> {
         });
 
         Some(quote! {
-            static PATTERNS: #lazy_lock<[(&#str_, #regex); #sz]> = #lazy_lock::new(|| [ #( #patterns )* ]);
+            static PATTERNS: #lazy_lock<[(&#str_, #regex); #sz]> = #lazy_lock::new(|| [ #( #patterns ),* ]);
 
             for (pattern, regex) in PATTERNS.iter() {
                 if !regex.is_match(s) {

--- a/xsd-parser/tests/feature/mod.rs
+++ b/xsd-parser/tests/feature/mod.rs
@@ -44,6 +44,7 @@ mod mixed_choice_with_any;
 mod mixed_content;
 mod mixed_content_groups;
 mod mixed_unexpected_text;
+mod multi_pattern_facets;
 mod namespaces_qualified;
 mod nested_group_reuse;
 mod nillable;

--- a/xsd-parser/tests/feature/multi_pattern_facets/example/default.xml
+++ b/xsd-parser/tests/feature/multi_pattern_facets/example/default.xml
@@ -1,0 +1,1 @@
+<tns:Voltage xmlns:tns="http://example.com">120V</tns:Voltage>

--- a/xsd-parser/tests/feature/multi_pattern_facets/example/invalid.xml
+++ b/xsd-parser/tests/feature/multi_pattern_facets/example/invalid.xml
@@ -1,0 +1,1 @@
+<tns:Voltage xmlns:tns="http://example.com">12345V</tns:Voltage>

--- a/xsd-parser/tests/feature/multi_pattern_facets/expected/default.rs
+++ b/xsd-parser/tests/feature/multi_pattern_facets/expected/default.rs
@@ -1,0 +1,48 @@
+use core::ops::Deref;
+use regex::Regex;
+use std::sync::LazyLock;
+use xsd_parser_types::quick_xml::ValidateError;
+pub type Voltage = VoltageType;
+#[derive(Debug)]
+pub struct VoltageType(pub String);
+impl VoltageType {
+    pub fn new(inner: String) -> Result<Self, ValidateError> {
+        Ok(Self(inner))
+    }
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+    pub fn validate_str(s: &str) -> Result<(), ValidateError> {
+        static PATTERNS: LazyLock<[(&str, Regex); 3usize]> = LazyLock::new(|| {
+            [
+                ("\\d+V", Regex::new("^(?:\\d+V)$").unwrap()),
+                ("[0-9]+V", Regex::new("^(?:[0-9]+V)$").unwrap()),
+                ("[0-9]{1,4}V", Regex::new("^(?:[0-9]{1,4}V)$").unwrap()),
+            ]
+        });
+        for (pattern, regex) in PATTERNS.iter() {
+            if !regex.is_match(s) {
+                return Err(ValidateError::Pattern(pattern));
+            }
+        }
+        Ok(())
+    }
+}
+impl From<VoltageType> for String {
+    fn from(value: VoltageType) -> String {
+        value.0
+    }
+}
+impl TryFrom<String> for VoltageType {
+    type Error = ValidateError;
+    fn try_from(value: String) -> Result<Self, ValidateError> {
+        Self::new(value)
+    }
+}
+impl Deref for VoltageType {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/xsd-parser/tests/feature/multi_pattern_facets/expected/quick_xml.rs
+++ b/xsd-parser/tests/feature/multi_pattern_facets/expected/quick_xml.rs
@@ -1,0 +1,77 @@
+use core::{ops::Deref, str::from_utf8};
+use regex::Regex;
+use std::{borrow::Cow, sync::LazyLock};
+use xsd_parser_types::{
+    misc::{Namespace, NamespacePrefix},
+    quick_xml::{
+        DeserializeBytes, DeserializeHelper, Error, SerializeBytes, SerializeHelper, ValidateError,
+        WithDeserializerFromBytes, WithSerializeToBytes,
+    },
+};
+pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
+pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
+pub const NS_XSI: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema-instance");
+pub const NS_TNS: Namespace = Namespace::new_const(b"http://example.com");
+pub const PREFIX_XS: NamespacePrefix = NamespacePrefix::new_const(b"xs");
+pub const PREFIX_XML: NamespacePrefix = NamespacePrefix::new_const(b"xml");
+pub const PREFIX_XSI: NamespacePrefix = NamespacePrefix::new_const(b"xsi");
+pub const PREFIX_TNS: NamespacePrefix = NamespacePrefix::new_const(b"tns");
+pub type Voltage = VoltageType;
+#[derive(Debug)]
+pub struct VoltageType(pub String);
+impl VoltageType {
+    pub fn new(inner: String) -> Result<Self, ValidateError> {
+        Ok(Self(inner))
+    }
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+    pub fn validate_str(s: &str) -> Result<(), ValidateError> {
+        static PATTERNS: LazyLock<[(&str, Regex); 3usize]> = LazyLock::new(|| {
+            [
+                ("\\d+V", Regex::new("^(?:\\d+V)$").unwrap()),
+                ("[0-9]+V", Regex::new("^(?:[0-9]+V)$").unwrap()),
+                ("[0-9]{1,4}V", Regex::new("^(?:[0-9]{1,4}V)$").unwrap()),
+            ]
+        });
+        for (pattern, regex) in PATTERNS.iter() {
+            if !regex.is_match(s) {
+                return Err(ValidateError::Pattern(pattern));
+            }
+        }
+        Ok(())
+    }
+}
+impl From<VoltageType> for String {
+    fn from(value: VoltageType) -> String {
+        value.0
+    }
+}
+impl TryFrom<String> for VoltageType {
+    type Error = ValidateError;
+    fn try_from(value: String) -> Result<Self, ValidateError> {
+        Self::new(value)
+    }
+}
+impl Deref for VoltageType {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl SerializeBytes for VoltageType {
+    fn serialize_bytes(&self, helper: &mut SerializeHelper) -> Result<Option<Cow<'_, str>>, Error> {
+        self.0.serialize_bytes(helper)
+    }
+}
+impl WithSerializeToBytes for VoltageType {}
+impl DeserializeBytes for VoltageType {
+    fn deserialize_bytes(helper: &mut DeserializeHelper, bytes: &[u8]) -> Result<Self, Error> {
+        let s = from_utf8(bytes).map_err(Error::from)?;
+        Self::validate_str(s).map_err(|error| (bytes, error))?;
+        let inner = String::deserialize_str(helper, s)?;
+        Ok(Self::new(inner).map_err(|error| (bytes, error))?)
+    }
+}
+impl WithDeserializerFromBytes for VoltageType {}

--- a/xsd-parser/tests/feature/multi_pattern_facets/expected/serde_quick_xml.rs
+++ b/xsd-parser/tests/feature/multi_pattern_facets/expected/serde_quick_xml.rs
@@ -1,0 +1,49 @@
+use core::ops::Deref;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use xsd_parser_types::quick_xml::ValidateError;
+pub type Voltage = VoltageType;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VoltageType(pub String);
+impl VoltageType {
+    pub fn new(inner: String) -> Result<Self, ValidateError> {
+        Ok(Self(inner))
+    }
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+    pub fn validate_str(s: &str) -> Result<(), ValidateError> {
+        static PATTERNS: LazyLock<[(&str, Regex); 3usize]> = LazyLock::new(|| {
+            [
+                ("\\d+V", Regex::new("^(?:\\d+V)$").unwrap()),
+                ("[0-9]+V", Regex::new("^(?:[0-9]+V)$").unwrap()),
+                ("[0-9]{1,4}V", Regex::new("^(?:[0-9]{1,4}V)$").unwrap()),
+            ]
+        });
+        for (pattern, regex) in PATTERNS.iter() {
+            if !regex.is_match(s) {
+                return Err(ValidateError::Pattern(pattern));
+            }
+        }
+        Ok(())
+    }
+}
+impl From<VoltageType> for String {
+    fn from(value: VoltageType) -> String {
+        value.0
+    }
+}
+impl TryFrom<String> for VoltageType {
+    type Error = ValidateError;
+    fn try_from(value: String) -> Result<Self, ValidateError> {
+        Self::new(value)
+    }
+}
+impl Deref for VoltageType {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/xsd-parser/tests/feature/multi_pattern_facets/expected/serde_xml_rs.rs
+++ b/xsd-parser/tests/feature/multi_pattern_facets/expected/serde_xml_rs.rs
@@ -1,0 +1,49 @@
+use core::ops::Deref;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use xsd_parser_types::quick_xml::ValidateError;
+pub type Voltage = VoltageType;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VoltageType(pub String);
+impl VoltageType {
+    pub fn new(inner: String) -> Result<Self, ValidateError> {
+        Ok(Self(inner))
+    }
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+    pub fn validate_str(s: &str) -> Result<(), ValidateError> {
+        static PATTERNS: LazyLock<[(&str, Regex); 3usize]> = LazyLock::new(|| {
+            [
+                ("\\d+V", Regex::new("^(?:\\d+V)$").unwrap()),
+                ("[0-9]+V", Regex::new("^(?:[0-9]+V)$").unwrap()),
+                ("[0-9]{1,4}V", Regex::new("^(?:[0-9]{1,4}V)$").unwrap()),
+            ]
+        });
+        for (pattern, regex) in PATTERNS.iter() {
+            if !regex.is_match(s) {
+                return Err(ValidateError::Pattern(pattern));
+            }
+        }
+        Ok(())
+    }
+}
+impl From<VoltageType> for String {
+    fn from(value: VoltageType) -> String {
+        value.0
+    }
+}
+impl TryFrom<String> for VoltageType {
+    type Error = ValidateError;
+    fn try_from(value: String) -> Result<Self, ValidateError> {
+        Self::new(value)
+    }
+}
+impl Deref for VoltageType {
+    type Target = String;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/xsd-parser/tests/feature/multi_pattern_facets/mod.rs
+++ b/xsd-parser/tests/feature/multi_pattern_facets/mod.rs
@@ -1,0 +1,137 @@
+use xsd_parser::{
+    config::{OptimizerFlags, SerdeXmlRsVersion},
+    Config, IdentType,
+};
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default()
+        .without_optimizer_flags(OptimizerFlags::USE_UNRESTRICTED_BASE_TYPE_SIMPLE)
+        .with_generate([(IdentType::Element, "tns:Voltage")])
+}
+
+/* default */
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/multi_pattern_facets/schema.xsd",
+        "tests/feature/multi_pattern_facets/expected/default.rs",
+        config(),
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+/* quick_xml */
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/feature/multi_pattern_facets/schema.xsd",
+        "tests/feature/multi_pattern_facets/expected/quick_xml.rs",
+        config().with_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::Voltage;
+
+    let obj = crate::utils::quick_xml_read_test::<Voltage, _>(
+        "tests/feature/multi_pattern_facets/example/default.xml",
+    );
+
+    assert_eq!(*obj, "120V");
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml_invalid() {
+    use quick_xml::Voltage;
+    use xsd_parser_types::quick_xml::{ErrorKind, ValidateError};
+
+    let err = crate::utils::quick_xml_read_test_result::<Voltage, _>(
+        "tests/feature/multi_pattern_facets/example/invalid.xml",
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err.kind,
+        ErrorKind::InvalidValue(_, ValidateError::Pattern(_))
+    ));
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}
+
+/* serde_xml_rs */
+
+#[test]
+fn generate_serde_xml_rs() {
+    generate_test(
+        "tests/feature/multi_pattern_facets/schema.xsd",
+        "tests/feature/multi_pattern_facets/expected/serde_xml_rs.rs",
+        config().with_serde_xml_rs(SerdeXmlRsVersion::Version08AndAbove),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs() {
+    use serde_xml_rs::Voltage;
+
+    let obj = crate::utils::serde_xml_rs_read_test::<Voltage, _>(
+        "tests/feature/multi_pattern_facets/example/default.xml",
+    );
+
+    assert_eq!(*obj, "120V");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs.rs");
+}
+
+/* serde_quick_xml */
+
+#[test]
+fn generate_serde_quick_xml() {
+    generate_test(
+        "tests/feature/multi_pattern_facets/schema.xsd",
+        "tests/feature/multi_pattern_facets/expected/serde_quick_xml.rs",
+        config().with_serde_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_quick_xml() {
+    use serde_quick_xml::Voltage;
+
+    let obj = crate::utils::serde_quick_xml_read_test::<Voltage, _>(
+        "tests/feature/multi_pattern_facets/example/default.xml",
+    );
+
+    assert_eq!(*obj, "120V");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_quick_xml.rs");
+}

--- a/xsd-parser/tests/feature/multi_pattern_facets/schema.xsd
+++ b/xsd-parser/tests/feature/multi_pattern_facets/schema.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://example.com"
+           targetNamespace="http://example.com"
+           elementFormDefault="qualified">
+
+    <xs:simpleType name="VoltageType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d+V"/>
+            <xs:pattern value="[0-9]+V"/>
+            <xs:pattern value="[0-9]{1,4}V"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="Voltage" type="tns:VoltageType"/>
+
+</xs:schema>


### PR DESCRIPTION
Fixes #247.

## Root cause

In `render_validate_pattern`, the `quote!` repetition was missing its comma separator:

```rust
// before
#lazy_lock::new(|| [ #( #patterns )* ])

// after
#lazy_lock::new(|| [ #( #patterns ),* ])
```

Without the comma, each subsequent tuple in the array was parsed as a function call on the previous element, producing E0618.

## Test

Added a new feature test `multi_pattern_facets` with a `VoltageType` restricted to three `xs:pattern` facets, covering all four backends. The expected output files were first generated with the broken code (confirming the compile error) and then regenerated after the fix to verify the PATTERNS array is well-formed.