### PR TITLE
Implement display name for content fields

### DIFF
--- a/xsd-parser/src/config/generator.rs
+++ b/xsd-parser/src/config/generator.rs
@@ -53,6 +53,12 @@ pub struct GeneratorConfig {
     /// See [`Generator::any_attributes_type`](crate::Generator::any_attributes_type)
     /// for details.
     pub any_attributes_type: String,
+
+    /// Name to use for the generated content field of the generated types.
+    ///
+    /// See [`Generator::content_display_name`](crate::Generator::content_display_name)
+    /// for details.
+    pub content_display_name: String,
 }
 
 impl Default for GeneratorConfig {
@@ -69,6 +75,7 @@ impl Default for GeneratorConfig {
             nillable_type: "::xsd_parser_types::xml::Nillable".into(),
             any_type: "::xsd_parser_types::xml::AnyElement".into(),
             any_attributes_type: "::xsd_parser_types::xml::AnyAttributes".into(),
+            content_display_name: "content".into(),
         }
     }
 }

--- a/xsd-parser/src/config/mod.rs
+++ b/xsd-parser/src/config/mod.rs
@@ -51,6 +51,13 @@ pub struct Config {
 }
 
 impl Config {
+    /// Set the name to use for the generated content field of the generated types.
+    pub fn with_content_display_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.generator.content_display_name = name.into();
+
+        self
+    }
+
     /// Adds the passed `schema` to the list of schemas to parse.
     pub fn with_schema<T>(mut self, schema: T) -> Self
     where

--- a/xsd-parser/src/lib.rs
+++ b/xsd-parser/src/lib.rs
@@ -356,7 +356,8 @@ pub fn exec_generator_with_ident_cache<'types>(
     let mut generator = Generator::new(types)
         .flags(config.flags)
         .box_flags(config.box_flags)
-        .typedef_mode(config.typedef_mode);
+        .typedef_mode(config.typedef_mode)
+        .content_display_name(config.content_display_name);
 
     generator = generator
         .text_type(config.text_type)

--- a/xsd-parser/src/models/data/complex.rs
+++ b/xsd-parser/src/models/data/complex.rs
@@ -196,6 +196,9 @@ pub struct ComplexDataContent<'types> {
     /// Maximum occurrence.
     pub max_occurs: MaxOccurs,
 
+    /// Field identifier of the element.
+    pub field_ident: Ident2,
+
     /// Actual target type of the content.
     pub target_type: PathData,
 

--- a/xsd-parser/src/pipeline/generator/data/complex.rs
+++ b/xsd-parser/src/pipeline/generator/data/complex.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::mem::take;
 
+use inflector::Inflector;
 use proc_macro2::{Ident as Ident2, Literal};
 use quote::format_ident;
 
@@ -23,6 +24,7 @@ use crate::models::{
     ElementIdent, TypeIdent,
 };
 use crate::pipeline::generator::ValueGeneratorMode;
+use crate::Name;
 
 use super::super::{Context, Error};
 
@@ -172,6 +174,7 @@ impl<'types> ComplexData<'types> {
     ) -> Result<Self, Error> {
         let base = ComplexBase::new(ctx, form, ComplexFlags::empty())?;
         let occurs = Occurs::from_occurs(min_occurs, max_occurs);
+        let field_ident = format_ident!("{}", ctx.content_display_name);
 
         let content_ref = ctx.get_or_create_type_ref_for_value(simple_type, occurs.is_direct())?;
         let target_type = content_ref.path.clone();
@@ -189,6 +192,7 @@ impl<'types> ComplexData<'types> {
             simple_type: Some(simple_type),
             min_occurs,
             max_occurs,
+            field_ident,
             target_type,
             extra_attributes: Vec::new(),
         };
@@ -206,6 +210,7 @@ impl<'types> ComplexData<'types> {
         })
     }
 
+    #[allow(clippy::too_many_lines)]
     fn new_enum(
         ctx: &mut Context<'_, 'types>,
         form: FormChoiceType,
@@ -303,6 +308,7 @@ impl<'types> ComplexData<'types> {
             }
         } else {
             let type_ref = ctx.current_type_ref();
+            let field_ident = format_ident!("{}", ctx.content_display_name);
 
             let target_type = (*type_ref.path).clone().with_ident(content_ident.clone());
             let target_type = PathData::from_path(target_type);
@@ -312,6 +318,7 @@ impl<'types> ComplexData<'types> {
                 simple_type: None,
                 min_occurs,
                 max_occurs,
+                field_ident,
                 target_type,
                 extra_attributes: Vec::new(),
             };
@@ -472,6 +479,7 @@ impl<'types> ComplexData<'types> {
             }
         } else {
             let type_ref = ctx.current_type_ref();
+            let field_ident = format_ident!("{}", ctx.content_display_name);
 
             let target_type = (*type_ref.path).clone().with_ident(content_ident.clone());
             let target_type = PathData::from_path(target_type);
@@ -481,6 +489,7 @@ impl<'types> ComplexData<'types> {
                 simple_type: None,
                 min_occurs,
                 max_occurs,
+                field_ident,
                 target_type,
                 extra_attributes: Vec::new(),
             };
@@ -716,8 +725,13 @@ impl<'types> ComplexDataElement<'types> {
         max_occurs: MaxOccurs,
         content_ident: Ident2,
     ) -> Self {
+        let s_name = ctx.content_display_name.clone();
+        let b_name = Literal::byte_string(s_name.as_bytes());
+        let field_ident = format_ident!("{s_name}");
+        let variant_ident = format_ident!("{}", s_name.to_pascal_case());
+
         let meta = ElementMeta {
-            ident: ElementIdent::named("content"),
+            ident: ElementIdent::new(Name::new_named(s_name.clone())),
             variant: ElementMetaVariant::Type {
                 type_: TypeIdent::UNKNOWN,
                 mode: ElementMode::Group,
@@ -741,11 +755,11 @@ impl<'types> ComplexDataElement<'types> {
         Self {
             origin,
             occurs,
-            s_name: "content".into(),
-            b_name: Literal::byte_string(b"content"),
+            s_name,
+            b_name,
             tag_name: TagName::default(),
-            field_ident: format_ident!("content"),
-            variant_ident: format_ident!("Content"),
+            field_ident,
+            variant_ident,
             target_type,
             need_indirection: false,
             target_is_dynamic: false,

--- a/xsd-parser/src/pipeline/generator/meta.rs
+++ b/xsd-parser/src/pipeline/generator/meta.rs
@@ -40,6 +40,9 @@ pub struct MetaData<'types> {
 
     /// Type to use to store unstructured `xs:anyAttribute` attributes.
     pub any_attributes_type: IdentPath,
+
+    /// Name to use for the generated content field of the generated types.
+    pub content_display_name: String,
 }
 
 impl MetaData<'_> {

--- a/xsd-parser/src/pipeline/generator/mod.rs
+++ b/xsd-parser/src/pipeline/generator/mod.rs
@@ -113,6 +113,7 @@ impl<'types> Generator<'types> {
             any_type: IdentPath::from_str("::xsd_parser_types::xml::AnyElement").unwrap(),
             any_attributes_type: IdentPath::from_str("::xsd_parser_types::xml::AnyAttributes")
                 .unwrap(),
+            content_display_name: String::from("content"),
         };
         let state = State {
             cache: BTreeMap::new(),
@@ -213,6 +214,13 @@ impl<'types> Generator<'types> {
         self.meta.any_attributes_type = path.try_into()?;
 
         Ok(self)
+    }
+
+    /// Set the name to use for the generated content field of the generated types.
+    pub fn content_display_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.meta.content_display_name = name.into();
+
+        self
     }
 
     /// Add the passed [`GeneratorFlags`] flags the generator should use for generating the code.

--- a/xsd-parser/src/pipeline/renderer/steps/quick_xml/collect_namespaces.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/quick_xml/collect_namespaces.rs
@@ -209,9 +209,11 @@ impl ComplexDataStruct<'_> {
 
         let field_calls: Vec<_> = match &self.mode {
             StructMode::Empty { .. } => Vec::new(),
-            StructMode::Content { .. } => {
+            StructMode::Content { content } => {
+                let field_ident = &content.field_ident;
+
                 vec![quote! {
-                    self.content.collect_namespaces(helper, bytes);
+                    self.#field_ident.collect_namespaces(helper, bytes);
                 }]
             }
             StructMode::All { elements, .. } | StructMode::Sequence { elements, .. } => elements

--- a/xsd-parser/src/pipeline/renderer/steps/quick_xml/deserialize.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/quick_xml/deserialize.rs
@@ -2379,6 +2379,7 @@ impl ComplexDataContent<'_> {
     }
 
     fn deserializer_field_decl(&self, ctx: &Context<'_, '_>) -> TokenStream {
+        let field_ident = &self.field_ident;
         let target_type = ctx.resolve_type_for_deserialize_module(&self.target_type);
 
         let target_type = match self.occurs {
@@ -2396,60 +2397,64 @@ impl ComplexDataContent<'_> {
         };
 
         quote! {
-            content: #target_type,
+            #field_ident: #target_type,
         }
     }
 
     fn deserializer_struct_field_init(&self, ctx: &Context<'_, '_>) -> TokenStream {
+        let field_ident = &self.field_ident;
+
         match self.occurs {
             Occurs::None => quote!(),
-            Occurs::Single | Occurs::Optional => quote!(content: None,),
+            Occurs::Single | Occurs::Optional => quote!(#field_ident: None,),
             Occurs::DynamicList | Occurs::StaticList(_) => {
                 let vec = resolve_build_in!(ctx, "::alloc::vec::Vec");
 
-                quote!(content: #vec::new(),)
+                quote!(#field_ident: #vec::new(),)
             }
         }
     }
 
     fn deserializer_struct_field_finish(&self, ctx: &mut Context<'_, '_>) -> TokenStream {
+        let field_ident = &self.field_ident;
         let convert = match self.occurs {
             Occurs::None => crate::unreachable!(),
             Occurs::Single => {
                 if ctx.has_defaultable_content() {
-                    quote!(helper.finish_default(self.content)?)
+                    quote!(helper.finish_default(self.#field_ident)?)
                 } else {
-                    quote!(helper.finish_content(self.content)?)
+                    quote!(helper.finish_content(self.#field_ident)?)
                 }
             }
             Occurs::Optional => {
-                quote! { self.content }
+                quote! { self.#field_ident }
             }
             Occurs::DynamicList => {
                 let min = self.min_occurs;
                 let max = self.max_occurs.render_opt();
 
                 if ctx.has_defaultable_content() {
-                    quote!(helper.finish_vec_default(#min, self.content)?)
+                    quote!(helper.finish_vec_default(#min, self.#field_ident)?)
                 } else {
-                    quote!(helper.finish_vec(#min, #max, self.content)?)
+                    quote!(helper.finish_vec(#min, #max, self.#field_ident)?)
                 }
             }
             Occurs::StaticList(sz) => {
                 if ctx.has_defaultable_content() {
-                    quote!(helper.finish_arr_default::<_, #sz>(self.content)?)
+                    quote!(helper.finish_arr_default::<_, #sz>(self.#field_ident)?)
                 } else {
-                    quote!(helper.finish_arr::<_, #sz>(self.content)?)
+                    quote!(helper.finish_arr::<_, #sz>(self.#field_ident)?)
                 }
             }
         };
 
         quote! {
-            content: #convert,
+            #field_ident: #convert,
         }
     }
 
     fn deserializer_struct_field_fn_store(&self, ctx: &Context<'_, '_>) -> TokenStream {
+        let field_ident = &self.field_ident;
         let target_type = ctx.resolve_type_for_deserialize_module(&self.target_type);
 
         let body = match self.occurs {
@@ -2459,15 +2464,15 @@ impl ComplexDataContent<'_> {
                     resolve_quick_xml_ident!(ctx, "::xsd_parser_types::quick_xml::ErrorKind");
 
                 quote! {
-                    if self.content.is_some() {
+                    if self.#field_ident.is_some() {
                         Err(#error_kind::DuplicateContent)?;
                     }
 
-                    self.content = Some(value);
+                    self.#field_ident = Some(value);
                 }
             }
             Occurs::DynamicList | Occurs::StaticList(_) => quote! {
-                self.content.push(value);
+                self.#field_ident.push(value);
             },
         };
 

--- a/xsd-parser/src/pipeline/renderer/steps/quick_xml/serialize.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/quick_xml/serialize.rs
@@ -1193,6 +1193,8 @@ impl ComplexDataContent<'_> {
         ctx: &Context<'_, '_>,
         state_ident: &Ident2,
     ) -> TokenStream {
+        let field_ident = &self.field_ident;
+
         match self.occurs {
             Occurs::None => crate::unreachable!(),
             Occurs::Single => {
@@ -1201,7 +1203,7 @@ impl ComplexDataContent<'_> {
 
                 quote! {
                     *self.state = #state_ident::Content__(
-                        #with_serializer::serializer(&self.value.content, None, false)?
+                        #with_serializer::serializer(&self.value.#field_ident, None, false)?
                     )
                 }
             }
@@ -1212,7 +1214,7 @@ impl ComplexDataContent<'_> {
                 quote! {
                     *self.state = #state_ident::Content__(
                         #iter_serializer::new(
-                            self.value.content.as_ref(),
+                            self.value.#field_ident.as_ref(),
                             None,
                             false
                         )
@@ -1226,7 +1228,7 @@ impl ComplexDataContent<'_> {
                 quote! {
                     *self.state = #state_ident::Content__(
                         #iter_serializer::new(
-                            &self.value.content[..],
+                            &self.value.#field_ident[..],
                             None,
                             false
                         )

--- a/xsd-parser/src/pipeline/renderer/steps/serde/quick_xml.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/serde/quick_xml.rs
@@ -390,6 +390,7 @@ impl ComplexDataStruct<'_> {
 
 impl ComplexDataContent<'_> {
     fn render_field_serde_quick_xml(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
+        let field_ident = &self.field_ident;
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.make_type(ctx, &target_type, false)?;
         let extra_attributes = &self.extra_attributes;
@@ -401,7 +402,7 @@ impl ComplexDataContent<'_> {
         Some(quote! {
             #( #[#extra_attributes] )*
             #[serde(#default rename = #name)]
-            pub content: #target_type,
+            pub #field_ident: #target_type,
         })
     }
 }

--- a/xsd-parser/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/serde/serde_xml_rs_v7.rs
@@ -392,6 +392,7 @@ impl ComplexDataStruct<'_> {
 
 impl ComplexDataContent<'_> {
     fn render_field_serde_xml_rs_v7(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
+        let field_ident = &self.field_ident;
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self.occurs.make_type(ctx, &target_type, false)?;
         let extra_attributes = &self.extra_attributes;
@@ -402,7 +403,7 @@ impl ComplexDataContent<'_> {
         Some(quote! {
             #( #[#extra_attributes] )*
             #[serde(#default rename = "$value")]
-            pub content: #target_type,
+            pub #field_ident: #target_type,
         })
     }
 }

--- a/xsd-parser/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/serde/serde_xml_rs_v8.rs
@@ -458,6 +458,7 @@ impl ComplexDataStruct<'_> {
 
 impl ComplexDataContent<'_> {
     fn render_field_serde_xml_rs_v8(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
+        let field_ident = &self.field_ident;
         let target_type = ctx.resolve_type_for_module(&self.target_type);
         let target_type = self
             .occurs
@@ -478,20 +479,20 @@ impl ComplexDataContent<'_> {
                 Some(quote! {
                     #( #[#extra_attributes] )*
                     #[serde(#default rename = "#text")]
-                    pub content: #enum_values_type,
+                    pub #field_ident: #enum_values_type,
                 })
             }
             Some((_, MetaTypeVariant::BuildIn(_) | MetaTypeVariant::Reference(_))) => {
                 Some(quote! {
                     #( #[#extra_attributes] )*
                     #[serde(#default rename = "#text")]
-                    pub content: #target_type,
+                    pub #field_ident: #target_type,
                 })
             }
             None | Some((_, _)) => Some(quote! {
                 #( #[#extra_attributes] )*
                 #[serde(#default rename = "#content")]
-                pub content: #target_type,
+                pub #field_ident: #target_type,
             }),
         }
     }

--- a/xsd-parser/src/pipeline/renderer/steps/types.rs
+++ b/xsd-parser/src/pipeline/renderer/steps/types.rs
@@ -368,13 +368,19 @@ impl ComplexDataStruct<'_> {
 
 impl ComplexDataContent<'_> {
     fn render_field(&self, ctx: &Context<'_, '_>) -> Option<TokenStream> {
-        let target_type = ctx.resolve_type_for_module(&self.target_type);
-        let target_type = self.occurs.make_type(ctx, &target_type, false)?;
-        let extra_attributes = &self.extra_attributes;
+        let Self {
+            occurs,
+            field_ident,
+            target_type,
+            extra_attributes,
+            ..
+        } = self;
+        let target_type = ctx.resolve_type_for_module(target_type);
+        let target_type = occurs.make_type(ctx, &target_type, false)?;
 
         Some(quote! {
             #( #[#extra_attributes] )*
-            pub content: #target_type,
+            pub #field_ident: #target_type,
         })
     }
 }

--- a/xsd-parser/tests/feature/content_display_name/example/default.xml
+++ b/xsd-parser/tests/feature/content_display_name/example/default.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:Foo xmlns:tns="http://example.com" content="an attribute value">the text value</tns:Foo>

--- a/xsd-parser/tests/feature/content_display_name/expected/default.rs
+++ b/xsd-parser/tests/feature/content_display_name/expected/default.rs
@@ -1,0 +1,6 @@
+pub type Foo = FooType;
+#[derive(Debug)]
+pub struct FooType {
+    pub content: Option<String>,
+    pub text_value: String,
+}

--- a/xsd-parser/tests/feature/content_display_name/expected/quick_xml.rs
+++ b/xsd-parser/tests/feature/content_display_name/expected/quick_xml.rs
@@ -1,0 +1,244 @@
+use xsd_parser_types::{
+    misc::{Namespace, NamespacePrefix},
+    quick_xml::{Error, WithDeserializer, WithSerializer},
+};
+pub const NS_XS: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema");
+pub const NS_XML: Namespace = Namespace::new_const(b"http://www.w3.org/XML/1998/namespace");
+pub const NS_XSI: Namespace = Namespace::new_const(b"http://www.w3.org/2001/XMLSchema-instance");
+pub const NS_TNS: Namespace = Namespace::new_const(b"http://example.com");
+pub const PREFIX_XS: NamespacePrefix = NamespacePrefix::new_const(b"xs");
+pub const PREFIX_XML: NamespacePrefix = NamespacePrefix::new_const(b"xml");
+pub const PREFIX_XSI: NamespacePrefix = NamespacePrefix::new_const(b"xsi");
+pub const PREFIX_TNS: NamespacePrefix = NamespacePrefix::new_const(b"tns");
+pub type Foo = FooType;
+#[derive(Debug)]
+pub struct FooType {
+    pub content: Option<String>,
+    pub text_value: String,
+}
+impl WithSerializer for FooType {
+    type Serializer<'x> = quick_xml_serialize::FooTypeSerializer<'x>;
+    fn serializer<'ser>(
+        &'ser self,
+        name: Option<&'ser str>,
+        is_root: bool,
+    ) -> Result<Self::Serializer<'ser>, Error> {
+        Ok(quick_xml_serialize::FooTypeSerializer {
+            value: self,
+            state: Box::new(quick_xml_serialize::FooTypeSerializerState::Init__),
+            name: name.unwrap_or("tns:FooType"),
+            is_root,
+        })
+    }
+}
+impl WithDeserializer for FooType {
+    type Deserializer = quick_xml_deserialize::FooTypeDeserializer;
+}
+pub mod quick_xml_deserialize {
+    use core::mem::replace;
+    use xsd_parser_types::quick_xml::{
+        BytesStart, ContentDeserializer, DeserializeHelper, Deserializer, DeserializerArtifact,
+        DeserializerEvent, DeserializerOutput, DeserializerResult, Error, ErrorKind, Event,
+        WithDeserializer,
+    };
+    #[derive(Debug)]
+    pub struct FooTypeDeserializer {
+        content: Option<String>,
+        text_value: Option<String>,
+        state__: Box<FooTypeDeserializerState>,
+    }
+    #[derive(Debug)]
+    enum FooTypeDeserializerState {
+        Init__,
+        Content__(<String as WithDeserializer>::Deserializer),
+        Unknown__,
+    }
+    impl FooTypeDeserializer {
+        fn from_bytes_start(
+            helper: &mut DeserializeHelper,
+            bytes_start: &BytesStart<'_>,
+        ) -> Result<Self, Error> {
+            let mut content: Option<String> = None;
+            for attrib in helper.filter_xmlns_attributes(bytes_start) {
+                let attrib = attrib?;
+                if matches!(
+                    helper.resolve_local_name(attrib.key, &super::NS_TNS),
+                    Some(b"content")
+                ) {
+                    helper.read_attrib(&mut content, b"content", &attrib.value)?;
+                } else {
+                    helper.raise_unexpected_attrib_checked(&attrib)?;
+                }
+            }
+            Ok(Self {
+                content: content,
+                text_value: None,
+                state__: Box::new(FooTypeDeserializerState::Init__),
+            })
+        }
+        fn finish_state(
+            &mut self,
+            helper: &mut DeserializeHelper,
+            state: FooTypeDeserializerState,
+        ) -> Result<(), Error> {
+            if let FooTypeDeserializerState::Content__(deserializer) = state {
+                self.store_content(deserializer.finish(helper)?)?;
+            }
+            Ok(())
+        }
+        fn store_content(&mut self, value: String) -> Result<(), Error> {
+            if self.text_value.is_some() {
+                Err(ErrorKind::DuplicateContent)?;
+            }
+            self.text_value = Some(value);
+            Ok(())
+        }
+        fn handle_content<'de>(
+            mut self,
+            helper: &mut DeserializeHelper,
+            output: DeserializerOutput<'de, String>,
+        ) -> DeserializerResult<'de, super::FooType> {
+            use FooTypeDeserializerState as S;
+            let DeserializerOutput {
+                artifact,
+                event,
+                allow_any,
+            } = output;
+            match artifact {
+                DeserializerArtifact::None => Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::None,
+                    event,
+                    allow_any,
+                }),
+                DeserializerArtifact::Data(data) => {
+                    self.store_content(data)?;
+                    let data = self.finish(helper)?;
+                    Ok(DeserializerOutput {
+                        artifact: DeserializerArtifact::Data(data),
+                        event,
+                        allow_any,
+                    })
+                }
+                DeserializerArtifact::Deserializer(deserializer) => {
+                    *self.state__ = S::Content__(deserializer);
+                    Ok(DeserializerOutput {
+                        artifact: DeserializerArtifact::Deserializer(self),
+                        event,
+                        allow_any,
+                    })
+                }
+            }
+        }
+    }
+    impl<'de> Deserializer<'de, super::FooType> for FooTypeDeserializer {
+        fn init(
+            helper: &mut DeserializeHelper,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::FooType> {
+            let (Event::Start(x) | Event::Empty(x)) = &event else {
+                return Ok(DeserializerOutput {
+                    artifact: DeserializerArtifact::None,
+                    event: DeserializerEvent::Break(event),
+                    allow_any: false,
+                });
+            };
+            Self::from_bytes_start(helper, x)?.next(helper, event)
+        }
+        fn next(
+            mut self,
+            helper: &mut DeserializeHelper,
+            event: Event<'de>,
+        ) -> DeserializerResult<'de, super::FooType> {
+            use FooTypeDeserializerState as S;
+            match replace(&mut *self.state__, S::Unknown__) {
+                S::Unknown__ => unreachable!(),
+                S::Init__ => {
+                    let output = ContentDeserializer::init(helper, event)?;
+                    self.handle_content(helper, output)
+                }
+                S::Content__(deserializer) => {
+                    let output = deserializer.next(helper, event)?;
+                    self.handle_content(helper, output)
+                }
+            }
+        }
+        fn finish(mut self, helper: &mut DeserializeHelper) -> Result<super::FooType, Error> {
+            let state = replace(&mut *self.state__, FooTypeDeserializerState::Unknown__);
+            self.finish_state(helper, state)?;
+            Ok(super::FooType {
+                content: self.content,
+                text_value: helper.finish_content(self.text_value)?,
+            })
+        }
+    }
+}
+pub mod quick_xml_serialize {
+    use xsd_parser_types::quick_xml::{
+        BytesEnd, BytesStart, Error, Event, SerializeHelper, Serializer, WithSerializer,
+    };
+    #[derive(Debug)]
+    pub struct FooTypeSerializer<'ser> {
+        pub(super) value: &'ser super::FooType,
+        pub(super) state: Box<FooTypeSerializerState<'ser>>,
+        pub(super) name: &'ser str,
+        pub(super) is_root: bool,
+    }
+    #[derive(Debug)]
+    pub(super) enum FooTypeSerializerState<'ser> {
+        Init__,
+        Content__(<String as WithSerializer>::Serializer<'ser>),
+        End__,
+        Done__,
+        Phantom__(&'ser ()),
+    }
+    impl<'ser> FooTypeSerializer<'ser> {
+        fn next_event(
+            &mut self,
+            helper: &mut SerializeHelper,
+        ) -> Result<Option<Event<'ser>>, Error> {
+            loop {
+                match &mut *self.state {
+                    FooTypeSerializerState::Init__ => {
+                        *self.state = FooTypeSerializerState::Content__(
+                            WithSerializer::serializer(&self.value.text_value, None, false)?,
+                        );
+                        let mut bytes = BytesStart::new(self.name);
+                        helper.begin_ns_scope();
+                        if self.is_root {
+                            helper.write_xmlns(
+                                &mut bytes,
+                                Some(&super::PREFIX_TNS),
+                                &super::NS_TNS,
+                            );
+                        }
+                        helper.write_attrib_opt(&mut bytes, "content", &self.value.content)?;
+                        return Ok(Some(Event::Start(bytes)));
+                    }
+                    FooTypeSerializerState::Content__(x) => match x.next(helper).transpose()? {
+                        Some(event) => return Ok(Some(event)),
+                        None => *self.state = FooTypeSerializerState::End__,
+                    },
+                    FooTypeSerializerState::End__ => {
+                        *self.state = FooTypeSerializerState::Done__;
+                        helper.end_ns_scope();
+                        return Ok(Some(Event::End(BytesEnd::new(self.name))));
+                    }
+                    FooTypeSerializerState::Done__ => return Ok(None),
+                    FooTypeSerializerState::Phantom__(_) => unreachable!(),
+                }
+            }
+        }
+    }
+    impl<'ser> Serializer<'ser> for FooTypeSerializer<'ser> {
+        fn next(&mut self, helper: &mut SerializeHelper) -> Option<Result<Event<'ser>, Error>> {
+            match self.next_event(helper) {
+                Ok(Some(event)) => Some(Ok(event)),
+                Ok(None) => None,
+                Err(error) => {
+                    *self.state = FooTypeSerializerState::Done__;
+                    Some(Err(error))
+                }
+            }
+        }
+    }
+}

--- a/xsd-parser/tests/feature/content_display_name/expected/serde_quick_xml.rs
+++ b/xsd-parser/tests/feature/content_display_name/expected/serde_quick_xml.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+pub type Foo = FooType;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FooType {
+    #[serde(default, rename = "@content")]
+    pub content: Option<String>,
+    #[serde(default, rename = "$text")]
+    pub text_value: String,
+}

--- a/xsd-parser/tests/feature/content_display_name/expected/serde_xml_rs.rs
+++ b/xsd-parser/tests/feature/content_display_name/expected/serde_xml_rs.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+pub type Foo = FooType;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FooType {
+    #[serde(default, rename = "@content")]
+    pub content: Option<String>,
+    #[serde(default, rename = "#text")]
+    pub text_value: String,
+}

--- a/xsd-parser/tests/feature/content_display_name/expected/serde_xml_rs_v7.rs
+++ b/xsd-parser/tests/feature/content_display_name/expected/serde_xml_rs_v7.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+pub type Foo = FooType;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FooType {
+    #[serde(default, rename = "content")]
+    pub content: Option<String>,
+    #[serde(default, rename = "$value")]
+    pub text_value: String,
+}

--- a/xsd-parser/tests/feature/content_display_name/mod.rs
+++ b/xsd-parser/tests/feature/content_display_name/mod.rs
@@ -1,0 +1,168 @@
+use xsd_parser::{config::SerdeXmlRsVersion, Config, IdentType};
+
+use crate::utils::{generate_test, ConfigEx};
+
+fn config() -> Config {
+    Config::test_default()
+        .with_generate([(IdentType::Element, "tns:Foo")])
+        .with_content_display_name("text_value")
+}
+
+/* default */
+
+#[test]
+fn generate_default() {
+    generate_test(
+        "tests/feature/content_display_name/schema.xsd",
+        "tests/feature/content_display_name/expected/default.rs",
+        config(),
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod default {
+    #![allow(unused_imports)]
+
+    include!("expected/default.rs");
+}
+
+/* quick_xml */
+
+#[test]
+fn generate_quick_xml() {
+    generate_test(
+        "tests/feature/content_display_name/schema.xsd",
+        "tests/feature/content_display_name/expected/quick_xml.rs",
+        config().with_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_quick_xml() {
+    use quick_xml::Foo;
+
+    let obj = crate::utils::quick_xml_read_test::<Foo, _>(
+        "tests/feature/content_display_name/example/default.xml",
+    );
+
+    assert_eq!(obj.content, Some("an attribute value".into()));
+    assert_eq!(obj.text_value, "the text value");
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn write_quick_xml() {
+    use quick_xml::FooType;
+
+    let obj = FooType {
+        content: Some("an attribute value".into()),
+        text_value: "the text value".into(),
+    };
+
+    crate::utils::quick_xml_write_test(
+        &obj,
+        "tns:Foo",
+        "tests/feature/content_display_name/example/default.xml",
+    );
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/quick_xml.rs");
+}
+
+/* serde_xml_rs v0.8 */
+
+#[test]
+fn generate_serde_xml_rs() {
+    generate_test(
+        "tests/feature/content_display_name/schema.xsd",
+        "tests/feature/content_display_name/expected/serde_xml_rs.rs",
+        config().with_serde_xml_rs(SerdeXmlRsVersion::Version08AndAbove),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs() {
+    use serde_xml_rs::Foo;
+
+    let obj = crate::utils::serde_xml_rs_read_test::<Foo, _>(
+        "tests/feature/content_display_name/example/default.xml",
+    );
+
+    assert_eq!(obj.content, Some("an attribute value".into()));
+    assert_eq!(obj.text_value, "the text value");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs.rs");
+}
+
+/* serde_xml_rs v0.7 */
+
+#[test]
+fn generate_serde_xml_rs_v7() {
+    generate_test(
+        "tests/feature/content_display_name/schema.xsd",
+        "tests/feature/content_display_name/expected/serde_xml_rs_v7.rs",
+        config().with_serde_xml_rs(SerdeXmlRsVersion::Version07AndBelow),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_xml_rs_v7() {
+    use serde_xml_rs_v7::Foo;
+
+    let obj = crate::utils::serde_xml_rs_v7_read_test::<Foo, _>(
+        "tests/feature/content_display_name/example/default.xml",
+    );
+
+    assert_eq!(obj.content, Some("an attribute value".into()));
+    assert_eq!(obj.text_value, "the text value");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_xml_rs_v7 {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_xml_rs_v7.rs");
+}
+
+/* serde_quick_xml */
+
+#[test]
+fn generate_serde_quick_xml() {
+    generate_test(
+        "tests/feature/content_display_name/schema.xsd",
+        "tests/feature/content_display_name/expected/serde_quick_xml.rs",
+        config().with_serde_quick_xml(),
+    );
+}
+
+#[test]
+#[cfg(not(feature = "update-expectations"))]
+fn read_serde_quick_xml() {
+    use serde_quick_xml::Foo;
+
+    let obj = crate::utils::serde_quick_xml_read_test::<Foo, _>(
+        "tests/feature/content_display_name/example/default.xml",
+    );
+
+    assert_eq!(obj.content, Some("an attribute value".into()));
+    assert_eq!(obj.text_value, "the text value");
+}
+
+#[cfg(not(feature = "update-expectations"))]
+mod serde_quick_xml {
+    #![allow(unused_imports)]
+
+    include!("expected/serde_quick_xml.rs");
+}

--- a/xsd-parser/tests/feature/content_display_name/schema.xsd
+++ b/xsd-parser/tests/feature/content_display_name/schema.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://example.com"
+    targetNamespace="http://example.com"
+    elementFormDefault="qualified">
+
+    <xs:complexType name="FooType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="content" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:element name="Foo" type="tns:FooType" />
+</xs:schema>

--- a/xsd-parser/tests/feature/mod.rs
+++ b/xsd-parser/tests/feature/mod.rs
@@ -16,6 +16,7 @@ mod choice_with_sequence;
 mod complex_type_empty;
 mod complex_type_with_group;
 mod complex_type_with_repeated_content;
+mod content_display_name;
 mod custom_type;
 mod defaultable_content;
 mod derive;


### PR DESCRIPTION
When generating code for a XSD schema that defines a `content` attribute, the corresponding field in the generated code will conflict with the field generated for the actual content of that element. To fix this we introduced a user defined display name for the generated content field.

Related to #265