### PR TITLE
Fix a panic in interpreter when using multiple schemas without `RESOLVE_INCLUDES`

### DIFF
--- a/xsd-parser/src/pipeline/interpreter/state/crate_node_cache.rs
+++ b/xsd-parser/src/pipeline/interpreter/state/crate_node_cache.rs
@@ -124,26 +124,28 @@ impl<'schema> NodeCacheProcessor<'_, 'schema> {
                     schema_location: Some(schema_location),
                     ..
                 }) => {
-                    let base = **info.dependencies.get(schema_location).unwrap();
-
-                    self.process_schema(base)?;
+                    if let Some(base) = info.dependencies.get(schema_location) {
+                        self.process_schema(**base)?;
+                    }
                 }
                 C::Include(x) => {
-                    let base = **info.dependencies.get(&x.schema_location).unwrap();
-
-                    self.process_schema(base)?;
+                    if let Some(base) = info.dependencies.get(&x.schema_location) {
+                        self.process_schema(**base)?;
+                    }
                 }
                 C::Override(x) => {
-                    let base = **info.dependencies.get(&x.schema_location).unwrap();
-
-                    self.process_schema(base)?;
-                    self.process_override(x, base)?;
+                    if let Some(base) = info.dependencies.get(&x.schema_location) {
+                        let base = **base;
+                        self.process_schema(base)?;
+                        self.process_override(x, base)?;
+                    }
                 }
                 C::Redefine(x) => {
-                    let base = **info.dependencies.get(&x.schema_location).unwrap();
-
-                    self.process_schema(base)?;
-                    self.process_redefine(x, base)?;
+                    if let Some(base) = info.dependencies.get(&x.schema_location) {
+                        let base = **base;
+                        self.process_schema(base)?;
+                        self.process_redefine(x, base)?;
+                    }
                 }
                 _ => (),
             }
@@ -927,7 +929,8 @@ impl<'schema> NodeCacheProcessor<'_, 'schema> {
 
         let ident = self
             .ident_cache
-            .resolve_for_schema(self.current_schema(), ident.clone())?;
+            .resolve_for_schema(self.current_schema(), ident.clone())
+            .or(self.ident_cache.resolve(ident))?;
 
         Ok(ident)
     }


### PR DESCRIPTION
When processing multiple XSD schemas that share a common schema via `<xsd:import>`, `xsd-parser` 1.5.2 panics in the interpreter if `ParserFlags::RESOLVE_INCLUDES` is **not** set.

The panic occurs in `crate_node_cache.rs:127` because the interpreter unconditionally calls `.unwrap()` on a `dependencies.get()` lookup. Without `RESOLVE_INCLUDES`, the `dependencies` map is empty, but the schema content still contains `<xsd:import>` elements with `schemaLocation` attributes.

Fixed by gracefully skipping the unresolved imports when loading and falling back to global resolution.